### PR TITLE
SimpleDelegatingSessionFactory.cs Connection Leak

### DIFF
--- a/src/Spring/Spring.Data.NHibernate21/Data/NHibernate/SimpleDelegatingSessionFactory.cs
+++ b/src/Spring/Spring.Data.NHibernate21/Data/NHibernate/SimpleDelegatingSessionFactory.cs
@@ -94,7 +94,7 @@ namespace Spring.Data.NHibernate
 
                     ISessionFactory factory = _targetSessionFactories[connectionString] as ISessionFactory;
 
-                    System.Diagnostics.Trace.WriteLine(String.Format("{0} =  {1}", System.Threading.Thread.CurrentThread.GetHashCode(), ((ISessionFactoryImplementor)factory).ConnectionProvider.GetConnection().ConnectionString));
+                    System.Diagnostics.Trace.WriteLine(String.Format("{0} =  {1}", System.Threading.Thread.CurrentThread.GetHashCode(), connectionString));
                     
                     return factory;
                 }


### PR DESCRIPTION
System.Diagnostics.Trace.WriteLine on line 97 of SimpleDelegatingSessionFactory.cs opens a database connection but never closes it.

Replaced ((ISessionFactoryImplementor)factory).ConnectionProvider.GetConnection().ConnectionString
With local variable: connectionString

An example of the unclosed connection can be found at: http://forum.springframework.net/showthread.php?9478-DelegatingLocalSessionFactoryObject-database-connection-leak
