### PR TITLE
Resolves SPRNET-1470 & SPRNET-1471

### DIFF
--- a/test/Spring/Spring.Core.Tests/Data/Spring/Objects/Factory/Xml/collectionConversionGeneric.xml
+++ b/test/Spring/Spring.Core.Tests/Data/Spring/Objects/Factory/Xml/collectionConversionGeneric.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<objects xmlns="http://www.springframework.net">
+
+  <object id="HasGenericIListProperty" type="Spring.Objects.TestObject, Spring.Core.Tests">
+    <property name="SomeGenericIListInt32">
+      <list>
+        <value>123</value>
+        <value>234</value>
+        <value>345</value>
+      </list>
+    </property>
+  </object>
+
+  <object id="HasGenericIDictionaryProperty" type="Spring.Objects.TestObject, Spring.Core.Tests">
+    <property name="SomeGenericIDictionaryStringInt32">
+      <dictionary>
+        <entry key="aaa" value="111"/>
+        <entry key="bbb" value="222"/>
+        <entry key="ccc" value="333"/>
+      </dictionary>
+    </property>
+  </object>
+
+  <object id="HasGenericIEnumerableProperty" type="Spring.Objects.TestObject, Spring.Core.Tests">
+    <property name="SomeGenericIEnumerableInt32">
+      <list>
+        <value>123</value>
+      </list>
+    </property>
+  </object>
+
+</objects>

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Xml/CollectionConversionGenericTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Xml/CollectionConversionGenericTests.cs
@@ -1,0 +1,116 @@
+#region License
+
+/*
+ * Copyright © 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+#region Imports
+
+using NUnit.Framework;
+using Spring.Objects.Factory.Support;
+using System.Collections;
+using Spring.Core.TypeConversion;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+#endregion
+
+namespace Spring.Objects.Factory.Xml
+{
+	/// <summary>
+	/// Unit and integration tests for collection conversion support
+	/// </summary>
+	/// <author>Choy Rim</author>
+	[TestFixture]
+    [Description("SPRNET-1470 Setting property of type IList<T> using <list/> without the @element-type specified fails.")]
+	public class CollectionConversionGenericTests
+	{
+	    private DefaultListableObjectFactory objectFactory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.objectFactory = new DefaultListableObjectFactory();
+            IObjectDefinitionReader reader = new XmlObjectDefinitionReader(this.objectFactory);
+            reader.LoadObjectDefinitions(new ReadOnlyXmlTestResource("collectionConversionGeneric.xml", GetType()));
+        }
+
+        [Test]
+        public void ShouldConvertListToGenericIList()
+        {
+            TestObject to = (TestObject)this.objectFactory.GetObject("HasGenericIListProperty");
+            var list = to.SomeGenericIListInt32;
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(123));
+            Assert.That(list[1], Is.EqualTo(234));
+            Assert.That(list[2], Is.EqualTo(345));
+        }
+
+        [Test]
+        public void ShouldConvertDictionaryToGenericIDictionary()
+        {
+            TestObject to = (TestObject)this.objectFactory.GetObject("HasGenericIDictionaryProperty");
+            var dict = to.SomeGenericIDictionaryStringInt32;
+            Assert.That(dict.Count, Is.EqualTo(3));
+            Assert.That(dict["aaa"], Is.EqualTo(111));
+            Assert.That(dict["bbb"], Is.EqualTo(222));
+            Assert.That(dict["ccc"], Is.EqualTo(333));
+        }
+
+        [Test]
+        public void ShouldConvertListToGenericIEnumerable()
+        {
+            TestObject to = (TestObject)this.objectFactory.GetObject("HasGenericIEnumerableProperty");
+            var enumerable = to.SomeGenericIEnumerableInt32;
+            Assert.That(enumerable.Count(), Is.EqualTo(1));
+            Assert.That(enumerable.First(), Is.EqualTo(123));
+        }
+
+        [Test]
+        public void ConvertArrayListToGenericIList() {
+            var xs = new ArrayList { "Mark Pollack" };
+            var ys = TypeConversionUtils.ConvertValueIfNecessary(typeof(IList<string>), xs, "ignored");
+            Assert.That(ys as IList<string>, Is.Not.Null);
+            var zs = (IList<string>)ys;
+            Assert.That(zs[0], Is.EqualTo("Mark Pollack"));
+        }
+
+        [Test]
+        public void ConvertHybridDictionaryToGenericIDictionary()
+        {
+            var xs = new HybridDictionary { { "first", 1 } };
+            var ys = TypeConversionUtils.ConvertValueIfNecessary(typeof(IDictionary<string, int>), xs, "ignored");
+            Assert.That(ys as IDictionary<string, int>, Is.Not.Null);
+            var zs = (IDictionary<string, int>)ys;
+            Assert.That(zs["first"], Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ConvertArrayListToGenericIEnumerable()
+        {
+            var xs = new ArrayList { "Mark Pollack" };
+            var ys = TypeConversionUtils.ConvertValueIfNecessary(typeof(IEnumerable<string>), xs, "ignored");
+            Assert.That(ys as IEnumerable<string>, Is.Not.Null);
+            var zs = (IEnumerable<string>)ys;
+            var zse = zs.GetEnumerator();
+            Assert.That(zse.MoveNext(), Is.True);
+            Assert.That(zse.Current, Is.EqualTo("Mark Pollack"));
+        }
+
+	}
+}

--- a/test/Spring/Spring.Core.Tests/Objects/TestObject.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/TestObject.cs
@@ -273,6 +273,10 @@ namespace Spring.Objects
             set { this.someGenericStringList = value; }
 	    }
 
+        public virtual IList<int> SomeGenericIListInt32 { get; set; }
+        public virtual IDictionary<string, int> SomeGenericIDictionaryStringInt32 { get; set; }
+        public virtual IEnumerable<int> SomeGenericIEnumerableInt32 { get; set; }
+
 	    public virtual NameValueCollection SomeNameValueCollection
 	    {
             get { return someNameValueCollection; }

--- a/test/Spring/Spring.Core.Tests/Spring.Core.Tests.2008.csproj
+++ b/test/Spring/Spring.Core.Tests/Spring.Core.Tests.2008.csproj
@@ -343,6 +343,7 @@
     <Compile Include="Objects\Factory\Xml\ArrayCtorDependencyObject.cs" />
     <Compile Include="Objects\Factory\Xml\CollectionMergingTests.cs" />
     <Compile Include="Objects\Factory\Xml\CollectionMergingGenericTests.cs" />
+    <Compile Include="Objects\Factory\Xml\CollectionConversionGenericTests.cs" />
     <Compile Include="Objects\Factory\Xml\LocaleTests.cs" />
     <Compile Include="Objects\Factory\Xml\NamespaceParserRegistryTests.cs" />
     <Compile Include="Objects\Factory\Xml\ObjectFactorySectionHandlerTests.cs" />
@@ -818,6 +819,7 @@
     <Content Include="Data\Spring\Objects\Factory\Xml\array-autowire.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\collectionMergingGeneric.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\collectionMerging.xml" />
+    <Content Include="Data\Spring\Objects\Factory\Xml\collectionConversionGeneric.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\ctor-args.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\objectNameGeneration.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\simple-constructor-arg.xml" />

--- a/test/Spring/Spring.Core.Tests/Spring.Core.Tests.2010.csproj
+++ b/test/Spring/Spring.Core.Tests/Spring.Core.Tests.2010.csproj
@@ -352,6 +352,7 @@
     <Compile Include="Objects\Factory\Xml\ArrayCtorDependencyObject.cs" />
     <Compile Include="Objects\Factory\Xml\CollectionMergingTests.cs" />
     <Compile Include="Objects\Factory\Xml\CollectionMergingGenericTests.cs" />
+    <Compile Include="Objects\Factory\Xml\CollectionConversionGenericTests.cs" />
     <Compile Include="Objects\Factory\Xml\LocaleTests.cs" />
     <Compile Include="Objects\Factory\Xml\NamespaceParserRegistryTests.cs" />
     <Compile Include="Objects\Factory\Xml\ObjectFactorySectionHandlerTests.cs" />
@@ -827,6 +828,7 @@
     <Content Include="Data\Spring\Objects\Factory\Xml\array-autowire.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\collectionMergingGeneric.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\collectionMerging.xml" />
+    <Content Include="Data\Spring\Objects\Factory\Xml\collectionConversionGeneric.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\ctor-args.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\objectNameGeneration.xml" />
     <Content Include="Data\Spring\Objects\Factory\Xml\simple-constructor-arg.xml" />


### PR DESCRIPTION
Recognizes properties of generic type IList<> and converts collections accordingly. TypeConversionUtils.TypeImplementsGenericInterface(candidateType, matchingInterface) does not handle the case where candidateType and matchingInterface are the same type. So it returns false for IList<> and IList<>.

Also implemented addition cases supporting IDictionary<> and IEnumerable<>.
