### PR TITLE
The default value for build-ems should be false for the `compile-net-4.0`

### DIFF
--- a/Spring.build
+++ b/Spring.build
@@ -609,7 +609,7 @@ Commandline Examples:
     <call target="copykeys" if="${project.build.sign}"/>
 	<call target="copylibs" />
     <call target="common.generate-assemblyinfo"/>
-    <property name="build-ems" value="true" overwrite="true" />
+    <property name="build-ems" value="false" overwrite="true" />
     <property name="build-nms" value="true" overwrite="true" />
     <property name="build-quartz" value="true" overwrite="true" />
     <property name="build-msmq" value="true" overwrite="true" />


### PR DESCRIPTION
The default value for build-ems should be false for the `compile-net-4.0` target

Reference: http://forum.springframework.net/showthread.php?9515-What-are-the-prerequisites-to-do-a-succesful-build-from-a-clean-check-out&p=25723#post25723
