### PR TITLE
Documentation updates to `Spring.Web.Mvc3` docs

### DIFF
--- a/doc/reference/src/web-mvc3.xml
+++ b/doc/reference/src/web-mvc3.xml
@@ -64,9 +64,9 @@
       </listitem>
     </itemizedlist>
 
-    <para>The Spring.NET distribution ships with a Web.Mvc Quick Start
-    application. The Web.Mvc QuickStart is the best way to see how to
-    integrate Spring.Web.Mvc into your own ASP.NET MVC applications.</para>
+    <para>The Spring.NET distribution ships with a Spring.Mvc3QuickStart
+    application. This QuickStart is the best way to see how to integrate
+    Spring.Web.Mvc into your own ASP.NET MVC applications.</para>
   </sect1>
 
   <sect1 xml:id="web-mvc3-contexts">


### PR DESCRIPTION
Fixes:
- xml config example references now uses `Spring.Web.Mvc3` assembly to allow copy-paste of example code
- reference mvc3 example by the name used in the distribution
