### PR TITLE
SPRNET-1501 - Add Support for SQLite 1.0.80

### DIFF
--- a/doc/reference/src/dbprovider.xml
+++ b/doc/reference/src/dbprovider.xml
@@ -287,7 +287,15 @@
 
       <listitem>
         <para><literal>SQLite-1.0.72</literal> - SQLite provider 1.0.72 for
-        .NET Framework 2.0 from http://sqlite.phxsoftware.com/ </para>
+        .NET Framework 2.0 from http://sqlite.phxsoftware.com/</para>
+      </listitem>
+
+      <listitem>
+        <para><literal>SQLite-1.0.80</literal> - SQLite provider 1.0.80 for
+        .NET Framework 2.0 SP2 and higher; from
+        http://system.data.sqlite.org/. For the
+        <literal>System.Data.SQLite.Linq</literal> assembly, .NET Framework
+        3.5 SP1 is required.</para>
       </listitem>
 
       <listitem>

--- a/src/Spring/Spring.Data/Data/Common/dbproviders.xml
+++ b/src/Spring/Spring.Data/Data/Common/dbproviders.xml
@@ -1588,8 +1588,56 @@
     </constructor-arg>
   </object>
 
-  <alias name="SQLite-1.0.65" alias="System.Data.SQLite"/>
+  <!-- 
+  from http://system.data.sqlite.org
+   * NuGet distributions: http://system.data.sqlite.org/index.html/doc/trunk/www/faq.wiki#q5
+   * NuGet page: http://www.nuget.org/packages/System.Data.SQLite
+   * Error code docs: http://www.sqlite.org/capi3ref.html#SQLITE_ABORT
+  -->
+  <object id="SQLite-1.0.80" type="Spring.Data.Common.DbProvider, Spring.Data" singleton="false">
+    <constructor-arg name="dbMetaData">
+      <object type="Spring.Data.Common.DbMetadata">
+        <constructor-arg name="productName" value="SQLite"/>
+        <constructor-arg name="assemblyName" value="System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="connectionType" value="System.Data.SQLite.SQLiteConnection, System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="commandType" value="System.Data.SQLite.SQLiteCommand, System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="parameterType" value="System.Data.SQLite.SQLiteParameter, System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="dataAdapterType" value="System.Data.SQLite.SQLiteDataAdapter , System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="commandBuilderType" value="System.Data.SQLite.SQLiteCommandBuilder, System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="commandBuilderDeriveParametersMethod" value="not supported"/>
+        <constructor-arg name="parameterDbType" value="System.Data.SQLite.TypeAffinity, System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="parameterDbTypeProperty" value="DbType"/>
+        <constructor-arg name="parameterIsNullableProperty" value="IsNullable"/>
+        <constructor-arg name="parameterNamePrefix" value=":"/>
+        <constructor-arg name="exceptionType" value="System.Data.SQLite.SQLiteException, System.Data.SQLite, Version=1.0.80.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139"/>
+        <constructor-arg name="useParameterNamePrefixInParameterCollection" value="true"/>
+        <constructor-arg name="useParameterPrefixInSql" value="true"/>
+        <constructor-arg name="bindByName" value="true"/>
+        <!-- this is only true for .net 1.1 kept it here just in case we want to revert back to this strategy for
+             obtaining error codes-->
+        <constructor-arg name="errorCodeExceptionExpression" value="ErrorCode.ToString('D')"/>
 
+        <property name="ErrorCodes.badSqlGrammarCodes">
+          <value></value>
+        </property>
+        <property name="ErrorCodes.DataAccessResourceFailureCodes">
+          <value>1</value>
+        </property>
+        <property name="ErrorCodes.DataIntegrityViolationCodes">
+          <value></value>
+        </property>
+        <property name="ErrorCodes.CannotAcquireLockCodes">
+          <value>15</value>
+        </property>
+        <property name="ErrorCodes.DeadlockLoserCodes">
+          <value>5,6</value>
+        </property>
+      </object>
+    </constructor-arg>
+
+  </object>
+
+  <alias name="SQLite-1.0.65" alias="System.Data.SQLite"/>
   
   <!-- Firebird -->
   

--- a/src/Spring/Spring.Data/Spring.Data.2010.csproj
+++ b/src/Spring/Spring.Data/Spring.Data.2010.csproj
@@ -299,7 +299,9 @@
     <Compile Include="Transaction\UnexpectedRollbackException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Data\Common\dbproviders.xml" />
+    <EmbeddedResource Include="Data\Common\dbproviders.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\Config\spring-database-1.1.xsd">


### PR DESCRIPTION
Fix for [SPRNET-1501](https://jira.springsource.org/browse/SPRNET-1501)
- Updated `dbprovider.xml` and documentation.
- The `System.Data.SQLite` alias is still set to `SQLite-1.0.65`,
  but we should consider setting it to `SQLite-1.0.80`

I'm not quite sure if these are all the required changes.
I created a simple NHibernate 3.2 app with sqlite database for verification.
That sample application is available [at github too](https://github.com/serra/spring-net-examples/tree/master/NHibernateMapByCode/NHibernateMapByCode).
To get the sample app to work, I only had to add a [sqlite dbprovider version 1.0.80](https://github.com/serra/spring-net-examples/blob/master/NHibernateMapByCode/NHibernateMapByCode/db.xml#L6). So I assume that the only required change is in `dbproviders.xml` and the docs.
