### PR TITLE
Resolved issue SPRNET-1547

### DIFF
--- a/src/Spring/Spring.Core/Context/Attributes/ScannedGenericObjectDefinition.cs
+++ b/src/Spring/Spring.Core/Context/Attributes/ScannedGenericObjectDefinition.cs
@@ -20,6 +20,7 @@
 
 using System;
 using Spring.Objects;
+using Spring.Objects.Factory.Config;
 using Spring.Objects.Factory.Support;
 using Spring.Objects.Factory.Xml;
 using Spring.Stereotype;
@@ -71,7 +72,20 @@ namespace Spring.Context.Attributes
             bool lazyInit = false;
             bool.TryParse(defaults.LazyInit, out lazyInit);
             IsLazyInit = lazyInit;
+            
+            if (!String.IsNullOrEmpty(defaults.Autowire))
+            {
+               AutowireMode = GetAutowireMode(defaults.Autowire);
+            }            
         }
+
+        private AutoWiringMode GetAutowireMode(string value)
+        {
+           AutoWiringMode autoWiringMode;
+           autoWiringMode = (AutoWiringMode)Enum.Parse(typeof(AutoWiringMode), value, true);
+           return autoWiringMode;
+        }
+
 
         private void ParseScopeAttribute()
         {

--- a/test/Spring/Spring.Core.Tests/Context/Config/ComponentScanObjectDefinitionParserTests.cs
+++ b/test/Spring/Spring.Core.Tests/Context/Config/ComponentScanObjectDefinitionParserTests.cs
@@ -120,6 +120,15 @@ namespace Spring.Context.Config
         }
 
         [Test]
+        public void ComponentsUseDefaultAutoWire()
+        {
+           _applicationContext = new XmlApplicationContext(ReadOnlyXmlTestResource.GetFilePath("ConfigFiles.ComponentScan5.xml", GetType()));
+           var prototypeDef = _applicationContext.ObjectFactory.GetObjectDefinition("Prototype");
+
+           Assert.That(prototypeDef.AutowireMode == AutoWiringMode.ByName);
+        }
+
+        [Test]
         public void ComponentWithQualifier()
         {
             _applicationContext = new XmlApplicationContext(ReadOnlyXmlTestResource.GetFilePath("ConfigFiles.ComponentScan6.xml", GetType()));

--- a/test/Spring/Spring.Core.Tests/Context/Config/ConfigFiles/ComponentScan5.xml
+++ b/test/Spring/Spring.Core.Tests/Context/Config/ConfigFiles/ComponentScan5.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <objects xmlns="http://www.springframework.net"
          xmlns:context="http://www.springframework.net/context"
-         default-lazy-init="true">
+         default-lazy-init="true" default-autowire="byName">
 
 	<context:component-scan base-assemblies="Spring.Core.Tests">
 		<context:include-filter type="regex" expression="ComponentScan.ComponentsUseDefaults.*"/>


### PR DESCRIPTION
ScannedGenericObjectDefinition doesn't apply default autowire mode

When it set the default-autowire attribute to a specific value, it doesn't apply to the ObjectDefinition
