### PR TITLE
An empty typeToLoad cause the Type Resolver to throw an error

### DIFF
--- a/src/Spring/Spring.Core/Context/Attributes/TypeFilters/AbstractLoadTypeFilter.cs
+++ b/src/Spring/Spring.Core/Context/Attributes/TypeFilters/AbstractLoadTypeFilter.cs
@@ -53,12 +53,14 @@ namespace Spring.Context.Attributes.TypeFilters
         {
             try
             {
-                RequiredType = TypeResolutionUtils.ResolveType(typeToLoad);
+                RequiredType = !string.IsNullOrEmpty(typeToLoad) ?
+                    TypeResolutionUtils.ResolveType(typeToLoad) : 
+                    null;
             }
             catch (Exception)
             {
                 RequiredType = null;
-                Logger.Error("Can't load type defined in exoression:" + typeToLoad);
+                Logger.Error("Can't load type defined in expression:" + typeToLoad);
             }
         }
 


### PR DESCRIPTION
Using the new Spring Code config with attribute configuration shows error message in Log Files but this error message can be prevented by checking the Type to Load upfront.
