### PR TITLE
Refactored DelegatingLocationSessionFactoryObject to support named conne...

### DIFF
--- a/src/Spring/Spring.Data.NHibernate/Data/NHibernate/DelegatingLocalSessionFactoryObject.cs
+++ b/src/Spring/Spring.Data.NHibernate/Data/NHibernate/DelegatingLocalSessionFactoryObject.cs
@@ -40,10 +40,18 @@ namespace Spring.Data.NHibernate
         protected override void PostProcessConfiguration(Configuration config)
         {
             // called before NewSessionFactory
-            if (!config.Properties.ContainsKey(Environment.ConnectionString))
-            {
-                throw new System.ArgumentException("Must specify connection string");
-            }
+            var settings = ConfigurationManager.ConnectionStrings[NHibernate.Cfg.Environment.ConnectionStringName];
+
+			if (settings != null)
+			{
+				config.Properties.Add(new KeyValuePair<string, string>(NHibernate.Cfg.Environment.ConnectionString, settings.ConnectionString));
+			}
+
+			// called before NewSessionFactory
+			if (!config.Properties.ContainsKey(NHibernate.Cfg.Environment.ConnectionString))
+			{
+				throw new System.ArgumentException("Must specify connection string. If connection_string_name is set to a value, make sure there exists a connection string with that name.");
+			}
         }
 
     }


### PR DESCRIPTION
...ctions

This will fail if you attempt to use a named connection instead of a connection string. I modified the PostProcessConfiguration to set the connection string if one could be looked up via NHibernates connection_string_name
