### PR TITLE
Replaced delegate syntax with easier to read lambda syntax

### DIFF
--- a/src/Spring/Spring.Data.NHibernate/Data/NHibernate/LocalSessionFactoryObject.cs
+++ b/src/Spring/Spring.Data.NHibernate/Data/NHibernate/LocalSessionFactoryObject.cs
@@ -773,7 +773,7 @@ namespace Spring.Data.NHibernate
 		    log.Info("Dropping database schema for NHibernate SessionFactory");
 		    HibernateTemplate hibernateTemplate = new HibernateTemplate(sessionFactory);
                 hibernateTemplate.Execute(
-                    new HibernateDelegate(delegate(ISession session)
+                    new HibernateDelegate(session =>
                                               {
                                                   IDbConnection con = session.Connection;
                                                   Dialect dialect = Dialect.GetDialect(Configuration.Properties);
@@ -803,7 +803,7 @@ namespace Spring.Data.NHibernate
 		    log.Info("Creating database schema for Hibernate SessionFactory");
 		    HibernateTemplate hibernateTemplate = new HibernateTemplate(sessionFactory);
 		    hibernateTemplate.Execute(
-			    new HibernateDelegate(delegate (ISession session)
+			    new HibernateDelegate(session =>
                 {
 					    IDbConnection con = session.Connection;
 					    Dialect dialect = Dialect.GetDialect(Configuration.Properties);
@@ -835,7 +835,7 @@ namespace Spring.Data.NHibernate
 		    HibernateTemplate hibernateTemplate = new HibernateTemplate(sessionFactory);
 		    hibernateTemplate.TemplateFlushMode = TemplateFlushMode.Never;
             hibernateTemplate.Execute(
-                new HibernateDelegate(delegate(ISession session)
+                new HibernateDelegate(session =>
                                           {
                                               IDbConnection con = session.Connection;
                                               Dialect dialect = Dialect.GetDialect(Configuration.Properties);

--- a/src/Spring/Spring.Messaging.Ems/Messaging/Ems/Core/EmsTemplate.cs
+++ b/src/Spring/Spring.Messaging.Ems/Messaging/Ems/Core/EmsTemplate.cs
@@ -1508,7 +1508,7 @@ namespace Spring.Messaging.Ems.Core
         public object BrowseSelectedWithDelegate(Queue queue, string messageSelector, BrowserDelegate action)
         {
             AssertUtils.ArgumentNotNull(action, "action");
-            return Execute(delegate(ISession session)
+            return Execute(session =>
                                {
                                    QueueBrowser browser = CreateBrowser(session, queue, messageSelector);
                                    try
@@ -1535,7 +1535,7 @@ namespace Spring.Messaging.Ems.Core
         public object BrowseSelectedWithDelegate(string queueName, string messageSelector, BrowserDelegate action)
         {
             AssertUtils.ArgumentNotNull(action, "action");
-            return Execute(delegate(ISession session)
+            return Execute(session =>
                                {
                                    Queue queue = (Queue)DestinationResolver.ResolveDestinationName(session, queueName, false);
                                    QueueBrowser browser = CreateBrowser(session, queue, messageSelector);

--- a/test/Spring/Spring.Core.Tests/Collections/Generic/ReadOnlyDictionaryTests.cs
+++ b/test/Spring/Spring.Core.Tests/Collections/Generic/ReadOnlyDictionaryTests.cs
@@ -65,12 +65,12 @@ namespace Spring.Collections.Generic
             //updating to nunit 2.5 would be nice to use Assert.That( SomeMethod, Throws.Exception<ArgumentException>());
             // Execute(delegate {  });
 
-            Execute(delegate { readonlyPersonDictionary["Mark"] = 4; });
-            Execute(delegate { readonlyPersonDictionary.Add("Gabriel", 3); });
-            Execute(delegate { readonlyPersonDictionary.Add(new KeyValuePair<string, int>("Mark", 38)); });
-            Execute(delegate { readonlyPersonDictionary.Clear();});
-            Execute(delegate { readonlyPersonDictionary.Remove("Mark"); });
-            Execute(delegate { readonlyPersonDictionary.Remove(new KeyValuePair<string, int>("Mark", 38)); });
+            Execute(() => { readonlyPersonDictionary["Mark"] = 4; });
+            Execute(() => readonlyPersonDictionary.Add("Gabriel", 3));
+            Execute(() => readonlyPersonDictionary.Add(new KeyValuePair<string, int>("Mark", 38)));
+            Execute(() => readonlyPersonDictionary.Clear());
+            Execute(() => readonlyPersonDictionary.Remove("Mark"));
+            Execute(() => readonlyPersonDictionary.Remove(new KeyValuePair<string, int>("Mark", 38)));
         }
 
         public void Execute(DoInTryCatch exceptionDelegate)

--- a/test/Spring/Spring.Core.Tests/Context/Config/ComponentScanObjectDefinitionParserAssemblyFilterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Context/Config/ComponentScanObjectDefinitionParserAssemblyFilterTests.cs
@@ -17,7 +17,7 @@ namespace Spring.Context.Config
         [Test]
         public void BaseAssembliesAttributeRequired()
         {
-            Assert.That(delegate { _applicationContext = new XmlApplicationContext(ReadOnlyXmlTestResource.GetFilePath("ConfigFiles.BaseAssemblyTestWithout.xml", GetType())); },
+            Assert.That(() => { _applicationContext = new XmlApplicationContext(ReadOnlyXmlTestResource.GetFilePath("ConfigFiles.BaseAssemblyTestWithout.xml", GetType())); },
                         Throws.Exception);
         }
 

--- a/test/Spring/Spring.Core.Tests/Context/Config/ComponentScanObjectDefinitionParserTypeFilterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Context/Config/ComponentScanObjectDefinitionParserTypeFilterTests.cs
@@ -47,7 +47,7 @@ namespace Spring.Context.Config
 
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(6));
             Assert.That(_applicationContext.GetObject("SomeIncludeType1"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace Spring.Context.Config
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(8));
             Assert.That(_applicationContext.GetObject("SomeIncludeType1"), Is.Not.Null);
             Assert.That(_applicationContext.GetObject("SomeIncludeType2"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace Spring.Context.Config
 
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(8));
             Assert.That(_applicationContext.GetObject("SomeIncludeType1"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace Spring.Context.Config
 
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(6));
             Assert.That(_applicationContext.GetObject("SomeIncludeType2"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace Spring.Context.Config
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(8));
             Assert.That(_applicationContext.GetObject("SomeIncludeType2"), Is.Not.Null);
             Assert.That(_applicationContext.GetObject("SomeExcludeType"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeIncludeType1"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeIncludeType1"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace Spring.Context.Config
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(8));
             Assert.That(_applicationContext.GetObject("SomeIncludeType1"), Is.Not.Null);
             Assert.That(_applicationContext.GetObject("SomeIncludeType2"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeExcludeType"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace Spring.Context.Config
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(8));
             Assert.That(_applicationContext.GetObject("SomeIncludeType1"), Is.Not.Null);
             Assert.That(_applicationContext.GetObject("SomeExcludeType"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeIncludeType2"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeIncludeType2"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace Spring.Context.Config
 
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(6));
             Assert.That(_applicationContext.GetObject("SomeIncludeType1"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeIncludeType2"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeIncludeType2"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace Spring.Context.Config
             Assert.That(_applicationContext.GetObjectDefinitionNames().Count, Is.EqualTo(8));
             Assert.That(_applicationContext.GetObject("SomeIncludeType2"), Is.Not.Null);
             Assert.That(_applicationContext.GetObject("SomeExcludeType"), Is.Not.Null);
-            Assert.That(delegate { _applicationContext.GetObject("SomeIncludeType1"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => { _applicationContext.GetObject("SomeIncludeType1"); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
     }

--- a/test/Spring/Spring.Core.Tests/Context/Support/AbstractApplicationContextTests.cs
+++ b/test/Spring/Spring.Core.Tests/Context/Support/AbstractApplicationContextTests.cs
@@ -68,14 +68,14 @@ namespace Spring.Context.Support
 	    {
 	        MockApplicationContext appCtx = new MockApplicationContext();
             bool secondHandlerExecuted = false;
-            appCtx.ContextEvent += new ApplicationEventHandler(delegate(object sender, ApplicationEventArgs e)
+            appCtx.ContextEvent += (sender, e) =>
             {
                 throw new ApplicationException("dummy");
-            } );
-            appCtx.ContextEvent += new ApplicationEventHandler(delegate(object sender, ApplicationEventArgs e)
+            };
+            appCtx.ContextEvent += (sender,  e) =>
             {
                 secondHandlerExecuted = true;
-            } );
+            };
 
 
 	        ApplicationException resultException = null;

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Attributes/PostConstructAttributeTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Attributes/PostConstructAttributeTests.cs
@@ -92,7 +92,7 @@ namespace Spring.Objects.Factory.Attributes
         [Test]
         public void WithArgumentMustThrowException()
         {
-            Assert.That(delegate { _applicationContext.GetObject("PostContructTestObject4"); }, Throws.Exception.TypeOf<ObjectCreationException>());
+            Assert.That(() => { _applicationContext.GetObject("PostContructTestObject4"); }, Throws.Exception.TypeOf<ObjectCreationException>());
         }
 
         [Test]

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Attributes/PreDestroyAttributeTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Attributes/PreDestroyAttributeTests.cs
@@ -103,7 +103,7 @@ namespace Spring.Objects.Factory.Attributes
         [Test]
         public void WithArgumentMustThrowException()
         {
-            Assert.That(delegate
+            Assert.That(() =>
             {
                 DestroyTester.ExecutionCount5 = 0;
                 var testObj = (PreDestroyTestObject5)_applicationContext.GetObject("PreDestroyTestObject5");

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Config/DelegateObjectFactoryConfigurerTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Config/DelegateObjectFactoryConfigurerTests.cs
@@ -46,10 +46,7 @@ namespace Spring.Objects.Factory.Config
             MockObjectFactoryPostProcessor mofp = new MockObjectFactoryPostProcessor();
 
             IConfigurableApplicationContext ctx = new XmlApplicationContext(false, "name", false, null);
-            ctx.AddObjectFactoryPostProcessor(new DelegateObjectFactoryConfigurer(delegate(IConfigurableListableObjectFactory of)
-                                                                                        {
-                                                                                            of.RegisterSingleton("mofp", mofp);
-                                                                                        }));
+            ctx.AddObjectFactoryPostProcessor(new DelegateObjectFactoryConfigurer(of => of.RegisterSingleton("mofp", mofp)));
 
             ctx.Refresh();
             Assert.IsTrue(mofp.Called);
@@ -61,10 +58,7 @@ namespace Spring.Objects.Factory.Config
             MockObjectFactoryPostProcessor mofp = new MockObjectFactoryPostProcessor();
 
             IConfigurableApplicationContext ctx = new XmlApplicationContext(false, "name", false, null);
-            ctx.AddObjectFactoryPostProcessor(new DelegateObjectFactoryConfigurer(delegate(IConfigurableListableObjectFactory of)
-                {
-                    of.RegisterSingleton("mofp", mofp);
-                }));
+            ctx.AddObjectFactoryPostProcessor(new DelegateObjectFactoryConfigurer(of => of.RegisterSingleton("mofp", mofp)));
 
             ctx.Refresh();
 

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Config/PropertyPlaceholderConfigurerTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Config/PropertyPlaceholderConfigurerTests.cs
@@ -150,7 +150,7 @@ namespace Spring.Objects.Factory.Config
             IConfigurableListableObjectFactory mock = mocks.StrictMock<IConfigurableListableObjectFactory>();
 			Expect.Call(mock.GetObjectDefinitionNames(false)).Return(new string [] {defName});
 			Expect.Call(mock.GetObjectDefinition(defName, false)).Return(def);
-            Expect.Call(delegate { mock.AddEmbeddedValueResolver(null); }).IgnoreArguments();
+            Expect.Call(() => mock.AddEmbeddedValueResolver(null)).IgnoreArguments();
             mocks.ReplayAll();
 
 			PropertyPlaceholderConfigurer cfg = new PropertyPlaceholderConfigurer();
@@ -180,7 +180,7 @@ namespace Spring.Objects.Factory.Config
             IConfigurableListableObjectFactory mock = mocks.StrictMock<IConfigurableListableObjectFactory>();
             Expect.Call(mock.GetObjectDefinitionNames(true)).Return(new string[] { defName });
             Expect.Call(mock.GetObjectDefinition(defName, true)).Return(def);
-            Expect.Call(delegate { mock.AddEmbeddedValueResolver(null); }).IgnoreArguments();
+            Expect.Call(() => mock.AddEmbeddedValueResolver(null)).IgnoreArguments();
             mocks.ReplayAll();
 
             PropertyPlaceholderConfigurer cfg = new PropertyPlaceholderConfigurer();
@@ -485,7 +485,7 @@ namespace Spring.Objects.Factory.Config
 			IConfigurableListableObjectFactory mock = mocks.StrictMock<IConfigurableListableObjectFactory>();
 			Expect.Call(mock.GetObjectDefinitionNames(false)).Return(new string[] {"foo"});
 			Expect.Call(mock.GetObjectDefinition(null, false)).IgnoreArguments().Return(def);
-            Expect.Call(delegate { mock.AddEmbeddedValueResolver(null); }).IgnoreArguments();
+            Expect.Call(() => mock.AddEmbeddedValueResolver(null)).IgnoreArguments();
             mocks.ReplayAll();
 
 			PropertyPlaceholderConfigurer cfg = new PropertyPlaceholderConfigurer();
@@ -583,7 +583,7 @@ namespace Spring.Objects.Factory.Config
 			IConfigurableListableObjectFactory mock = mocks.StrictMock<IConfigurableListableObjectFactory>();
 			Expect.Call(mock.GetObjectDefinitionNames(false)).Return(new string [] {defName});
 			Expect.Call(mock.GetObjectDefinition(defName, false)).Return(def);
-            Expect.Call(delegate { mock.AddEmbeddedValueResolver(null); }).IgnoreArguments();
+            Expect.Call(() => mock.AddEmbeddedValueResolver(null)).IgnoreArguments();
             mocks.ReplayAll();
 
 			PropertyPlaceholderConfigurer cfg = new PropertyPlaceholderConfigurer();

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/DefaultListableObjectFactoryTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/DefaultListableObjectFactoryTests.cs
@@ -1617,7 +1617,7 @@ namespace Spring.Objects.Factory
 		    lbf.RegisterObjectDefinition("bd1", bd1);
 		    lbf.RegisterObjectDefinition("bd2", bd2);
 
-            Assert.That(delegate { lbf.GetObject<TestObject>(); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => lbf.GetObject<TestObject>(), Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]
@@ -1635,7 +1635,7 @@ namespace Spring.Objects.Factory
             Assert.That(lbf.GetObject("bd1", typeof(TestObject)), Is.SameAs(actual));
 
 		    lbf.RegisterObjectDefinition("bd2", bd2);
-            Assert.That(delegate { lbf.GetObject<TestObject>(); }, Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
+            Assert.That(() => lbf.GetObject<TestObject>(), Throws.Exception.TypeOf<NoSuchObjectDefinitionException>());
         }
 
         [Test]

--- a/test/Spring/Spring.Core.Tests/Util/DefensiveEventRaiserTests.cs
+++ b/test/Spring/Spring.Core.Tests/Util/DefensiveEventRaiserTests.cs
@@ -54,9 +54,9 @@ namespace Spring.Util
 
             OneThirstyDude dude = new OneThirstyDude();
             Soda bru = new Soda();
-            bru.Pop += new PopHandler(delegate { firstCall = true; });
-            bru.Pop += new PopHandler(delegate { secondCall = true; throw new Exception(); });
-            bru.Pop += new PopHandler(delegate { thirdCall = true; });
+            bru.Pop += (sender, soda) => firstCall = true;
+			bru.Pop += (sender, soda) => { secondCall = true; throw new Exception(); };
+			bru.Pop += (sender, soda) => { thirdCall = true; };
 
             DefensiveEventRaiser eventRaiser = new DefensiveEventRaiser();
 

--- a/test/Spring/Spring.Data.Integration.Tests/Data/AdoTemplatePerformanceTests.cs
+++ b/test/Spring/Spring.Data.Integration.Tests/Data/AdoTemplatePerformanceTests.cs
@@ -178,7 +178,7 @@ namespace Spring.Data
 
             TransactionTemplate tt = new TransactionTemplate(tm);
             double timeElapsed = 0;
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                start = DateTime.Now;
                                for (int i = 0; i < numIterations; i++)

--- a/test/Spring/Spring.Data.Integration.Tests/Data/Generic/GenericAdoTemplateTests.cs
+++ b/test/Spring/Spring.Data.Integration.Tests/Data/Generic/GenericAdoTemplateTests.cs
@@ -71,7 +71,7 @@ namespace Spring.Data.Generic
         public void CommandDelegateUsage()
         {
             string name = "Jack";
-            int count = adoTemplate.Execute<int>(delegate(DbCommand command)
+            int count = adoTemplate.Execute<int>(command =>
                                                      {
                                                          command.CommandText =
                                                              "select count(*) from TestObjects where Name = @Name";
@@ -90,7 +90,7 @@ namespace Spring.Data.Generic
         public void CommandDelegateUsageDownCast()
         {
             string name = "Jack";
-            int count = adoTemplate.Execute<int>(delegate(DbCommand command)
+			int count = adoTemplate.Execute<int>((DbCommand command) =>
                                                      {
                                                          SqlCommand sqlCommand = command as SqlCommand;
                                                          command.CommandText =

--- a/test/Spring/Spring.Data.Integration.Tests/Data/NestedTxScopeTests.cs
+++ b/test/Spring/Spring.Data.Integration.Tests/Data/NestedTxScopeTests.cs
@@ -56,7 +56,7 @@ namespace Spring.Data
 
             TransactionTemplate tt = new TransactionTemplate(tm);
             tt.PropagationBehavior = TransactionPropagation.Required;
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                if (System.Transactions.Transaction.Current != null) Console.WriteLine("tx 1 id = " + System.Transactions.Transaction.Current.TransactionInformation.LocalIdentifier);
                                Console.WriteLine("tx 1 'IsNewTransaction' = " + status.IsNewTransaction);
@@ -64,7 +64,7 @@ namespace Spring.Data
                                TransactionTemplate tt2 = new TransactionTemplate(tm);
                                tt2.PropagationBehavior = TransactionPropagation.RequiresNew;
                                
-                               tt2.Execute(delegate(ITransactionStatus status2)
+                               tt2.Execute(status2 =>
                                                {
                                                    if (System.Transactions.Transaction.Current != null) Console.WriteLine("tx 2 = " + System.Transactions.Transaction.Current.TransactionInformation.LocalIdentifier);
                                                    Console.WriteLine("tx 2 'IsNewTransaction' = " + status2.IsNewTransaction);

--- a/test/Spring/Spring.Data.Tests/Data/Core/TxScopeTransactionManagerIntegrationTests.cs
+++ b/test/Spring/Spring.Data.Tests/Data/Core/TxScopeTransactionManagerIntegrationTests.cs
@@ -129,7 +129,7 @@ namespace Spring.Data.Core
             Assert.IsFalse(TransactionSynchronizationManager.SynchronizationActive);
             Assert.IsNull(TransactionSynchronizationManager.CurrentTransactionName);
             Assert.IsFalse(TransactionSynchronizationManager.CurrentTransactionReadOnly);
-            tt.Execute(delegate (ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                Assert.IsTrue(TransactionSynchronizationManager.SynchronizationActive);
                                TransactionSynchronizationManager.RegisterSynchronization(sync);

--- a/test/Spring/Spring.Data.Tests/Data/Core/TxScopeTransactionManagerTests.cs
+++ b/test/Spring/Spring.Data.Tests/Data/Core/TxScopeTransactionManagerTests.cs
@@ -70,7 +70,7 @@ namespace Spring.Data.Core
             tm.TransactionSynchronization = TransactionSynchronizationState.Always;
 
             TransactionTemplate tt = new TransactionTemplate(tm);
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                Assert.IsTrue(TransactionSynchronizationManager.SynchronizationActive);
                                Assert.IsFalse(TransactionSynchronizationManager.CurrentTransactionReadOnly);
@@ -110,7 +110,7 @@ namespace Spring.Data.Core
             Exception ex = new ArgumentException("test exception");
             try
             {
-                tt.Execute(delegate(ITransactionStatus status)
+                tt.Execute(status =>
                                {
                                    Assert.IsTrue(TransactionSynchronizationManager.SynchronizationActive);
                                    Assert.IsFalse(TransactionSynchronizationManager.CurrentTransactionReadOnly);
@@ -162,14 +162,14 @@ namespace Spring.Data.Core
 
             TransactionTemplate tt = new TransactionTemplate(tm);
             tt.PropagationBehavior = TransactionPropagation.RequiresNew;
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                Assert.IsTrue(status.IsNewTransaction, "Is new transaction");
                                Assert.IsTrue(TransactionSynchronizationManager.SynchronizationActive, "Synchronization active");
                                Assert.IsFalse(TransactionSynchronizationManager.CurrentTransactionReadOnly);
                                Assert.IsTrue(TransactionSynchronizationManager.ActualTransactionActive);
 
-                               tt.Execute(delegate(ITransactionStatus status2)
+                               tt.Execute(status2 =>
                                               {
                                                   Assert.IsTrue(TransactionSynchronizationManager.SynchronizationActive, "Synchronization active");
                                                   Assert.IsTrue(status2.IsNewTransaction, "Is new transaction");

--- a/test/Spring/Spring.Messaging.Nms.Tests/Messaging/Nms/Connections/MessageTransactionManagerTests.cs
+++ b/test/Spring/Spring.Messaging.Nms.Tests/Messaging/Nms/Connections/MessageTransactionManagerTests.cs
@@ -112,7 +112,7 @@ namespace Spring.Messaging.Nms.Connections
             nt.Execute(new AssertSessionCallback(session));
 
             TransactionTemplate tt = new TransactionTemplate(tm);
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                nt.Execute(new AssertSessionCallback(session));
                                return null;
@@ -144,7 +144,7 @@ namespace Spring.Messaging.Nms.Connections
             nt.Execute(new AssertSessionCallback(session));
 
             TransactionTemplate tt = new TransactionTemplate(tm);
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                nt.Execute(new AssertSessionCallback(session));
                                status.SetRollbackOnly();
@@ -194,7 +194,7 @@ namespace Spring.Messaging.Nms.Connections
 
             TransactionTemplate tt = new TransactionTemplate(tm);
             tt.PropagationBehavior = TransactionPropagation.NotSupported;
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                nt.Execute(new AssertNotSameSessionCallback(session));
                                return null;
@@ -243,7 +243,7 @@ namespace Spring.Messaging.Nms.Connections
 
             TransactionTemplate tt = new TransactionTemplate(tm);
             tt.PropagationBehavior = TransactionPropagation.RequiresNew;
-            tt.Execute(delegate(ITransactionStatus status)
+            tt.Execute(status =>
                            {
                                nt.Execute(new AssertNotSameSessionCallback(session));
                                return null;

--- a/test/Spring/Spring.Messaging.Nms.Tests/Messaging/Nms/Core/MessageTemplateTests.cs
+++ b/test/Spring/Spring.Messaging.Nms.Tests/Messaging/Nms/Core/MessageTemplateTests.cs
@@ -115,7 +115,7 @@ namespace Spring.Messaging.Nms.Core
             mocks.ReplayAll();
 
             MsgPriority priority = MsgPriority.Highest;
-            template.Execute(delegate(ISession session, IMessageProducer producer)
+            template.Execute((session, producer) =>
             {
                 bool b = session.Transacted;
                 priority = producer.Priority;
@@ -149,7 +149,7 @@ namespace Spring.Messaging.Nms.Core
 
             mocks.ReplayAll();
 
-            template.Execute(delegate(ISession session, IMessageProducer producer)
+            template.Execute((session, producer) =>
                                  {
                                      bool b = session.Transacted;
                                      MsgPriority priority = producer.Priority;
@@ -183,7 +183,7 @@ namespace Spring.Messaging.Nms.Core
 
             mocks.ReplayAll();
 
-            template.Execute(delegate(ISession session)
+            template.Execute(session =>
                                  {
                                      bool b = session.Transacted;
                                      return null;
@@ -223,12 +223,12 @@ namespace Spring.Messaging.Nms.Core
 
             try
             {
-                template.Execute(delegate(ISession session)
+                template.Execute(session =>
                                      {
                                          bool b = session.Transacted;
                                          return null;
                                      });
-                template.Execute(delegate(ISession session)
+                template.Execute(session =>
                                      {
                                          bool b = session.Transacted;
                                          return null;
@@ -241,7 +241,7 @@ namespace Spring.Messaging.Nms.Core
                 //In Java this test was doing 'double-duty' and testing TransactionAwareConnectionFactoryProxy, which has
                 //not been implemented in .NET
 
-                template.Execute(delegate(ISession session)
+                template.Execute(session =>
                                      {
                                          bool b = session.Transacted;
                                          return null;

--- a/test/Spring/Spring.Messaging.Tests/Messaging/Core/MessageQueueTemplateTests.cs
+++ b/test/Spring/Spring.Messaging.Tests/Messaging/Core/MessageQueueTemplateTests.cs
@@ -197,7 +197,7 @@ namespace Spring.Messaging.Core
         {
             IPlatformTransactionManager txManager = new MessageQueueTransactionManager();
             TransactionTemplate transactionTemplate = new TransactionTemplate(txManager);
-            transactionTemplate.Execute(delegate(ITransactionStatus status)
+            transactionTemplate.Execute(status =>
                                             {
                                                 if (messageQueueObjectName == null)
                                                 {
@@ -218,7 +218,7 @@ namespace Spring.Messaging.Core
         {
             IPlatformTransactionManager txManager = new TxScopeTransactionManager();
             TransactionTemplate transactionTemplate = new TransactionTemplate(txManager);
-            transactionTemplate.Execute(delegate(ITransactionStatus status)
+            transactionTemplate.Execute(status =>
                                             {
                                                 q.ConvertAndSend("Hello World 1");
                                                 q.ConvertAndSend("Hello World 2");


### PR DESCRIPTION
Lambda syntax is easier on the eyes when reading the code.
