### PR TITLE
Removed redundant delegate creation

### DIFF
--- a/src/Spring/Spring.Core/Util/SystemUtils.cs
+++ b/src/Spring/Spring.Core/Util/SystemUtils.cs
@@ -64,7 +64,7 @@ namespace Spring.Util
             {
                 lock (assemblyResolverLock)
                 {
-                    AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(LoadedAssemblyResolver);
+                    AppDomain.CurrentDomain.AssemblyResolve += LoadedAssemblyResolver;
                     assemblyResolverRegistered = true;
                 }
             }

--- a/src/Spring/Spring.Data.NHibernate/Data/NHibernate/Support/OpenSessionInViewModule.cs
+++ b/src/Spring/Spring.Data.NHibernate/Data/NHibernate/Support/OpenSessionInViewModule.cs
@@ -57,8 +57,8 @@ namespace Spring.Data.NHibernate.Support
         /// <param name="context">The standard HTTP application context</param>
         public void Init( HttpApplication context )
         {
-            context.BeginRequest += new EventHandler(context_BeginRequest);
-            context.EndRequest += new EventHandler(context_EndRequest);
+            context.BeginRequest += context_BeginRequest;
+            context.EndRequest += context_EndRequest;
         }
          /// <summary>
          /// A do nothing dispose method.

--- a/src/Spring/Spring.Messaging.Nms/Messaging/Nms/Connections/SingleConnectionFactory.cs
+++ b/src/Spring/Spring.Messaging.Nms/Messaging/Nms/Connections/SingleConnectionFactory.cs
@@ -352,11 +352,11 @@ namespace Spring.Messaging.Nms.Connections
             if (reconnectOnException)
             {
                 //add reconnect exception handler first to exception chain.
-                con.ExceptionListener += new ExceptionListener(this.OnException);
+                con.ExceptionListener += this.OnException;
             }
             if (ExceptionListener != null)
             {
-                con.ExceptionListener += new ExceptionListener(ExceptionListener.OnException);                
+                con.ExceptionListener += ExceptionListener.OnException;
             }
         }
 

--- a/src/Spring/Spring.Messaging.Nms/Messaging/Nms/Listener/SimpleMessageListenerContainer.cs
+++ b/src/Spring/Spring.Messaging.Nms/Messaging/Nms/Listener/SimpleMessageListenerContainer.cs
@@ -180,7 +180,7 @@ namespace Spring.Messaging.Nms.Listener
         protected override void PrepareSharedConnection(IConnection connection)
         {
             base.PrepareSharedConnection(connection);
-            connection.ExceptionListener += new ExceptionListener(OnException);
+            connection.ExceptionListener += OnException;
         }
 
 
@@ -313,7 +313,7 @@ namespace Spring.Messaging.Nms.Listener
 			
 	        SimpleMessageListener listener = new SimpleMessageListener(this, session);
             // put in explicit registration with 'new' for compilation on .NET 1.1
-            consumer.Listener += new Apache.NMS.MessageListener(listener.OnMessage); 
+            consumer.Listener += listener.OnMessage;
             return consumer;
         }
 

--- a/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentFactory.cs
+++ b/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentFactory.cs
@@ -150,7 +150,7 @@ namespace Spring.EnterpriseServices
         {
             ValidateConfiguration();
             componentType = Type.GetTypeFromProgID(Name, Server);
-            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
         }
 
         #endregion

--- a/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentHelper.cs
+++ b/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentHelper.cs
@@ -83,7 +83,7 @@ namespace Spring.EnterpriseServices
         {
             // this is to ensure, that assemblies placed next to the component assembly can be loaded
             // even when they are not strong named.
-            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(CurrentDomain_AssemblyResolve);
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
             FileInfo componentAssemblyFile = new FileInfo(componentType.Assembly.Location);
             FileInfo assemblyFile = new FileInfo(componentAssemblyFile.FullName);
 

--- a/src/Spring/Spring.Web.Conversation.NHibernate3/Web/Conversation/HttpModule/ConversationModule.cs
+++ b/src/Spring/Spring.Web.Conversation.NHibernate3/Web/Conversation/HttpModule/ConversationModule.cs
@@ -73,7 +73,7 @@ namespace Spring.Web.Conversation.HttpModule
             if (HttpContext.Current.Handler is Page)
             {
                 Page page = (Page)HttpContext.Current.Handler;
-                page.Unload += new EventHandler(page_Unload);
+                page.Unload += page_Unload;
 
                 if (HttpContext.Current.Session != null)
                 {

--- a/src/Spring/Spring.Web/Context/Support/WebApplicationContext.cs
+++ b/src/Spring/Spring.Web/Context/Support/WebApplicationContext.cs
@@ -156,7 +156,7 @@ namespace Spring.Context.Support
             ILog s_weblog = LogManager.GetLogger(typeof(WebApplicationContext));
 
             // register for ContextRegistry.Cleared event - we need to discard our cache in this case
-            ContextRegistry.Cleared += new EventHandler(OnContextRegistryCleared);
+            ContextRegistry.Cleared += OnContextRegistryCleared;
 
 #if !MONO_2_0
             if (HttpRuntime.AppDomainAppVirtualPath != null) // check if we're within an ASP.NET AppDomain!

--- a/src/Spring/Spring.Web/Context/Support/WebSupportModule.cs
+++ b/src/Spring/Spring.Web/Context/Support/WebSupportModule.cs
@@ -145,8 +145,8 @@ namespace Spring.Context.Support
                 VirtualEnvironment.SetInitialized();
             }
 
-            app.PreRequestHandlerExecute += new EventHandler(OnConfigureHandler);
-            app.EndRequest += new EventHandler(VirtualEnvironment.RaiseEndRequest);
+            app.PreRequestHandlerExecute += OnConfigureHandler;
+            app.EndRequest += VirtualEnvironment.RaiseEndRequest;
 
             // TODO: this is only a workaround to get us up & running in IIS7/integrated mode
             // We must review all code for relative virtual paths - they must be resolved to application-relative paths

--- a/src/Spring/Spring.Web/Objects/Factory/Support/WebObjectFactory.cs
+++ b/src/Spring/Spring.Web/Objects/Factory/Support/WebObjectFactory.cs
@@ -87,8 +87,8 @@ namespace Spring.Objects.Factory.Support
                     if (s_eventHandlersRegistered) return;
 
                     if (log.IsDebugEnabled) log.Debug("hooking up event handlers");
-                    VirtualEnvironment.EndRequest += new VirtualEnvironment.RequestEventHandler(OnEndRequest);
-                    VirtualEnvironment.EndSession += new VirtualEnvironment.SessionEventHandler(OnEndSession);
+                    VirtualEnvironment.EndRequest += OnEndRequest;
+                    VirtualEnvironment.EndSession += OnEndSession;
 
                     s_eventHandlersRegistered = true;
                 }

--- a/src/Spring/Spring.Web/Web/UI/Controls/TabularMultiView.cs
+++ b/src/Spring/Spring.Web/Web/UI/Controls/TabularMultiView.cs
@@ -220,11 +220,11 @@ namespace Spring.Web.UI.Controls
 		{
 			// create menu tabstrip
 			_tabContainer = CreateTabContainer();
-			_tabContainer.Click += new TabCommandEventHandler(OnSelectTabCommand);
+			_tabContainer.Click += OnSelectTabCommand;
 
 			// create multiview container
 			_multiView = new MultiView();
-			_multiView.ActiveViewChanged += new EventHandler(OnActiveViewChanged);
+			_multiView.ActiveViewChanged += OnActiveViewChanged;
 
 			// add views previously parsed
 			for (int i = 0; i < _parsedViews.Count; i++) _multiView.Controls.Add((Control) _parsedViews[i]);

--- a/test/Spring/Spring.Web.Conversation.NHibernate3.Tests/Conversation/SerializeConversationTestModule.cs
+++ b/test/Spring/Spring.Web.Conversation.NHibernate3.Tests/Conversation/SerializeConversationTestModule.cs
@@ -61,8 +61,8 @@ namespace Spring.Web.Conversation
         /// <param name="context"></param>
         public void Init(HttpApplication context)
         {
-            context.PreRequestHandlerExecute += new EventHandler(context_PreRequestHandlerExecute);
-            context.PostRequestHandlerExecute += new EventHandler(context_PostRequestHandlerExecute);
+            context.PreRequestHandlerExecute += context_PreRequestHandlerExecute;
+            context.PostRequestHandlerExecute += context_PostRequestHandlerExecute;
         }
 
         /// <summary>


### PR DESCRIPTION
An example of this would be

context.EndRequest += new EventHandler(context_EndRequest);

to

context.EndRequest += context_EndRequest;

The compiler is smart enough to figure this out on its own.
