### PR TITLE
HibernateTransactionManager.GetIDbTransaction() does not work with subclasses of AdoTransaction

### DIFF
--- a/src/Spring/Spring.Data.NHibernate/Data/NHibernate/HibernateTransactionManager.cs
+++ b/src/Spring/Spring.Data.NHibernate/Data/NHibernate/HibernateTransactionManager.cs
@@ -667,7 +667,7 @@ namespace Spring.Data.NHibernate
             {
                 try
                 {
-                    FieldInfo fi = hibernateAdoTx.GetType().GetField("trans", BindingFlags.Instance | BindingFlags.NonPublic);
+                    FieldInfo fi = typeof(AdoTransaction).GetField("trans", BindingFlags.Instance | BindingFlags.NonPublic);
                     adoTransaction = fi.GetValue(hibernateAdoTx) as IDbTransaction;
                 }
                 catch (Exception e)


### PR DESCRIPTION
If HibernateTransactionManager.GetIDbTransaction() receives as parameter a subclass of AdoTransaction, it fails to retrieve the field trans that contains the IDbTransaction. The reason is that through reflection there's no acces to private fields of superclasses.

This patch fixes that.