### PR TITLE
Multiple PropertyPlaceholderConfigurers fail in AbstractObjectFactory

### DIFF
--- a/src/Spring/Spring.Core/Objects/Factory/Support/AbstractObjectFactory.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Support/AbstractObjectFactory.cs
@@ -1685,7 +1685,7 @@ namespace Spring.Objects.Factory.Support
         /// <summary>
         /// String Resolver applied to Autowired value injections
         /// </summary>
-        private ISet embeddedValueResolvers = new SortedSet(new OrderComparator());
+        private ISet embeddedValueResolvers = new SortedSet(new ObjectOrderComparator());
 
         /// <summary>
         /// Indicates whether any IInstantiationAwareBeanPostProcessors have been registered

--- a/src/Spring/Spring.Core/Objects/Factory/Support/AbstractObjectFactory.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Support/AbstractObjectFactory.cs
@@ -1685,7 +1685,7 @@ namespace Spring.Objects.Factory.Support
         /// <summary>
         /// String Resolver applied to Autowired value injections
         /// </summary>
-        private ISet embeddedValueResolvers = new SortedSet();
+        private ISet embeddedValueResolvers = new SortedSet(new OrderComparator());
 
         /// <summary>
         /// Indicates whether any IInstantiationAwareBeanPostProcessors have been registered

--- a/test/Spring/Spring.Core.Tests/Data/Spring/Objects/Factory/Config/FirstPropertyPlaceholderConfigurer.xml
+++ b/test/Spring/Spring.Core.Tests/Data/Spring/Objects/Factory/Config/FirstPropertyPlaceholderConfigurer.xml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright 2004 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<objects xmlns="http://www.springframework.net">
+
+  <object id="testObject" type="Spring.Objects.TestObject, Spring.Core.Tests">
+    <property name="Name" value="${SomeName}" />
+  </object>
+
+  <object name="propertyplaceholder_100"
+          type="Spring.Objects.Factory.Config.PropertyPlaceholderConfigurer, Spring.Core">
+    <property name="Order" value="100"/>
+    <property name="EnvironmentVariableMode" value="never"/>
+    <property name="IgnoreUnresolvablePlaceholders" value="false"/>
+    <property name="Properties">
+      <name-values>
+        <add key="SomeName" value="wrong_name" />
+      </name-values>
+    </property>
+  </object>
+</objects>

--- a/test/Spring/Spring.Core.Tests/Data/Spring/Objects/Factory/Config/SecondPropertyPlaceholderConfigurer.xml
+++ b/test/Spring/Spring.Core.Tests/Data/Spring/Objects/Factory/Config/SecondPropertyPlaceholderConfigurer.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright 2004 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<objects xmlns="http://www.springframework.net">
+  <object name="propertyplaceholder_90"
+          type="Spring.Objects.Factory.Config.PropertyPlaceholderConfigurer, Spring.Core">
+    <property name="Order" value="90"/>
+    <property name="EnvironmentVariableMode" value="never"/>
+    <property name="IgnoreUnresolvablePlaceholders" value="false"/>
+    <property name="Properties">
+      <name-values>
+        <add key="SomeName" value="correct_name" />
+      </name-values>
+    </property>
+  </object>
+</objects>

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Config/PropertyPlaceholderConfigurerTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Config/PropertyPlaceholderConfigurerTests.cs
@@ -635,5 +635,21 @@ namespace Spring.Objects.Factory.Config
             Assert.AreEqual(2, to.Computers.Count);
             Assert.IsTrue(to.PeriodicTable.Contains("C"));
         }
+
+        [Test]
+        public void WithMultipleXml_MultiplePropertyPlaceholderConfigurersAndOrder_CanReplaceValueFromOtherXml()
+        {
+            var context =
+                new XmlApplicationContext(
+                    new[]
+                        {
+                            "file://Spring/Objects/Factory/Config/FirstPropertyPlaceholderConfigurer.xml",
+                            "file://Spring/Objects/Factory/Config/SecondPropertyPlaceholderConfigurer.xml"
+                        });
+
+            var testObject = context.GetObject<TestObject>("testObject");
+
+            Assert.AreEqual("correct_name", testObject.Name);
+        }
     }
 }

--- a/test/Spring/Spring.Core.Tests/Spring.Core.Tests.2010.csproj
+++ b/test/Spring/Spring.Core.Tests/Spring.Core.Tests.2010.csproj
@@ -872,6 +872,8 @@
     <Content Include="Data\Spring\Context\Support\SPRNET-192.xml" />
     <Content Include="Data\Spring\Objects\Factory\concurrent.xml" />
     <Content Include="Data\Spring\Objects\Factory\Config\AnotherDaoConfig.xml" />
+    <Content Include="Data\Spring\Objects\Factory\Config\SecondPropertyPlaceholderConfigurer.xml" />
+    <Content Include="Data\Spring\Objects\Factory\Config\FirstPropertyPlaceholderConfigurer.xml" />
     <Content Include="Data\Spring\Objects\Factory\Config\PPCWithTypesTests.xml" />
     <Content Include="Data\Spring\Objects\Factory\Config\TypeAliases.xml" />
     <Content Include="Data\Spring\Objects\Factory\Config\DaoConfig.xml" />


### PR DESCRIPTION
We discovered a possible bug in AbstractObjectFactory when upgrading from Spring.Net 1.3.1 to 2.0.0
Our usage of multiple PropertyPlaceholderConfigurers in different context files failed with the following error:
Spring.Objects.ObjectsException : Errored while postprocessing an object factory.  ----> System.InvalidOperationException : Failed to compare two elements in the array.  ----> System.ArgumentException : At least one object must implement IComparable.

The IOrder interface implemented in PPC is not used and IComparable is not implemented leading to this error. Adding a OrderComparer to the SortedSet constructor fixes this problem.

I added a new test to PropertyPlaceholderConfigurerTests which reproduces this error.

best regards
Thor Stenbæk
