### PR TITLE
The connection was not being effectively closed due to

### DIFF
--- a/src/Spring/Spring.Web.Conversation.NHibernate3/Data/NHibernate/Support/SessionPerConversationScope.cs
+++ b/src/Spring/Spring.Web.Conversation.NHibernate3/Data/NHibernate/Support/SessionPerConversationScope.cs
@@ -437,7 +437,11 @@ namespace Spring.Data.NHibernate.Support
                     else
                     {
                         if (tmpSession.IsConnected)
-                            tmpSession.Disconnect();
+                        {
+                            IDbConnection conn = tmpSession.Disconnect();
+                            if (conn != null && conn.State == ConnectionState.Open)
+                                conn.Close();
+                        }
                     }
                     RemoveSession(tmpSession);
                 }


### PR DESCRIPTION
'NHibernate.ISession.Disconnect ()' contract:
        //
        // Summary:
        //     Disconnect the ISession from the current ADO.NET
connection.
        //
        // Returns:
        //     The connection provided by the application or null
        //
        // Remarks:
        //     If the connection was obtained by Hibernate, close it or
return it to the
        //     connection pool. Otherwise return it to the application.
This is used by
        //     applications which require long transactions.