### PR TITLE
URL Cleanup

### DIFF
--- a/build-support/appveyor-database-integration-tests-setup-scripts.cmd
+++ b/build-support/appveyor-database-integration-tests-setup-scripts.cmd
@@ -1,5 +1,5 @@
 rem scripts to setup integration test database on CI server
-rem NOTE: sqlcmd params are hard-coded to credentials and instance name for SQL Server 2012 as per http://www.appveyor.com/docs/services-databases
+rem NOTE: sqlcmd params are hard-coded to credentials and instance name for SQL Server 2012 as per https://www.appveyor.com/docs/services-databases
 
 rem first, create the databases and the SpringQA user
 sqlcmd -S ".\SQL2017" -U sa -P Password12! -i "%APPVEYOR_BUILD_FOLDER%\build-support\create-integration-test-databases-and-users.sql"

--- a/doc/reference/lib/fop-0.95/fop.bat
+++ b/doc/reference/lib/fop-0.95/fop.bat
@@ -6,7 +6,7 @@ REM  The ASF licenses this file to You under the Apache License, Version 2.0
 REM  (the "License"); you may not use this file except in compliance with
 REM  the License.  You may obtain a copy of the License at
 REM
-REM      http://www.apache.org/licenses/LICENSE-2.0
+REM      https://www.apache.org/licenses/LICENSE-2.0
 REM
 REM  Unless required by applicable law or agreed to in writing, software
 REM  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.appveyor.com/docs/services-databases migrated to:  
  https://www.appveyor.com/docs/services-databases ([https](https://www.appveyor.com/docs/services-databases) result 301).