### PR TITLE
CacheResultAdvice: lock on write to hashtable

### DIFF
--- a/src/Spring/Spring.Aop/Aspects/Cache/CacheResultAdvice.cs
+++ b/src/Spring/Spring.Aop/Aspects/Cache/CacheResultAdvice.cs
@@ -78,7 +78,14 @@ namespace Spring.Aspects.Cache
                 CacheResultItemsAttribute[] itemInfoArray = (CacheResultItemsAttribute[])GetCustomAttributes(method, typeof(CacheResultItemsAttribute));
 
                 cacheResultInfo = new CacheResultInfo(resultInfo, itemInfoArray);
-                _cacheResultAttributeCache[method] = cacheResultInfo;
+                // need lock! Hashtable support only one writer!
+                lock (_cacheResultAttributeCache)
+                {
+                    if (!_cacheResultAttributeCache.Contains(method))
+                    {
+                        _cacheResultAttributeCache[method] = cacheResultInfo;
+                    }
+                }
             }
             return cacheResultInfo;
         }

--- a/src/Spring/Spring.Aop/Aspects/Cache/CacheResultAdvice.cs
+++ b/src/Spring/Spring.Aop/Aspects/Cache/CacheResultAdvice.cs
@@ -29,6 +29,7 @@ using AopAlliance.Intercept;
 using Spring.Caching;
 using Spring.Util;
 using System;
+using System.Collections.Concurrent;
 
 #endregion
 
@@ -66,27 +67,18 @@ namespace Spring.Aspects.Cache
             }
         }
 
-        private readonly Hashtable _cacheResultAttributeCache = new Hashtable();
+        private readonly ConcurrentDictionary<MethodInfo, CacheResultInfo> _cacheResultAttributeCache = new();
 
         private CacheResultInfo GetCacheResultInfo(MethodInfo method)
         {
-            CacheResultInfo cacheResultInfo = (CacheResultInfo)_cacheResultAttributeCache[method];
-            // no need for locking here - last one wins
-            if (cacheResultInfo == null)
+            var cacheResultInfo = _cacheResultAttributeCache.GetOrAdd(method, _ =>
             {
-                CacheResultAttribute resultInfo = (CacheResultAttribute)GetCustomAttribute(method, typeof(CacheResultAttribute));
-                CacheResultItemsAttribute[] itemInfoArray = (CacheResultItemsAttribute[])GetCustomAttributes(method, typeof(CacheResultItemsAttribute));
+                var resultInfo = (CacheResultAttribute) GetCustomAttribute(method, typeof(CacheResultAttribute));
+                var itemInfoArray = (CacheResultItemsAttribute[]) GetCustomAttributes(method, typeof(CacheResultItemsAttribute));
 
-                cacheResultInfo = new CacheResultInfo(resultInfo, itemInfoArray);
-                // need lock! Hashtable support only one writer!
-                lock (_cacheResultAttributeCache)
-                {
-                    if (!_cacheResultAttributeCache.Contains(method))
-                    {
-                        _cacheResultAttributeCache[method] = cacheResultInfo;
-                    }
-                }
-            }
+                return new CacheResultInfo(resultInfo, itemInfoArray);
+            });
+
             return cacheResultInfo;
         }
 


### PR DESCRIPTION
Put a lock on writes to the hashtable to fix concurrency problems