### PR TITLE
ReferenceNode throws KeyNotFoundException when CurrentObjectFactory wasn't provided in variables.

### DIFF
--- a/build-support/nuke-build/Build.Test.cs
+++ b/build-support/nuke-build/Build.Test.cs
@@ -48,7 +48,7 @@ public partial class Build
 
                     if (!EnvironmentInfo.IsWin)
                     {
-                        s = s.SetFramework("net5.0");
+                        s = s.SetFramework("net6.0");
                     }
 
                     return s;

--- a/build-support/nuke-build/_build.csproj
+++ b/build-support/nuke-build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..\..</NukeRootDirectory>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+    <PackageReference Include="Nuke.Common" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -56,9 +56,9 @@ else {
     # Install by channel or version
     $DotNetDirectory = "$TempDirectory\dotnet-win"
     if (!(Test-Path variable:DotNetVersion)) {
-        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
     } else {
-        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
     }
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -42,6 +42,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <LangVersion>latest</LangVersion>
+    <TargetFullFrameworkVersion>net462</TargetFullFrameworkVersion>
 
   </PropertyGroup>
 

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Common/Spring.AopQuickStart.Common.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Common/Spring.AopQuickStart.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step1/Spring.AopQuickStart.Step1.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step1/Spring.AopQuickStart.Step1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step2/Spring.AopQuickStart.Step2.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step2/Spring.AopQuickStart.Step2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step3/Spring.AopQuickStart.Step3.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step3/Spring.AopQuickStart.Step3.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step4/Spring.AopQuickStart.Step4.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step4/Spring.AopQuickStart.Step4.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step5/Spring.AopQuickStart.Step5.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step5/Spring.AopQuickStart.Step5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step6/Spring.AopQuickStart.Step6.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step6/Spring.AopQuickStart.Step6.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step7/Spring.AopQuickStart.Step7.csproj
+++ b/examples/Spring/Spring.AopQuickStart/src/Spring.AopQuickStart.Step7/Spring.AopQuickStart.Step7.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.AopQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.CachingQuickStart/src/Spring.CachingQuickStart.Web/Spring.CachingQuickStart.Web.csproj
+++ b/examples/Spring/Spring.CachingQuickStart/src/Spring.CachingQuickStart.Web/Spring.CachingQuickStart.Web.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Spring.CachingQuickStart</RootNamespace>
     <AssemblyName>Spring.CachingQuickStart.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
@@ -35,13 +35,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Spring.Aop">
-      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Aop\net461\Spring.Aop.dll</HintPath>
+      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Aop\net462\Spring.Aop.dll</HintPath>
     </Reference>
     <Reference Include="Spring.Core">
-      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Aop\net461\Spring.Core.dll</HintPath>
+      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Aop\net462\Spring.Core.dll</HintPath>
     </Reference>
     <Reference Include="Spring.Web">
-      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Web\net461\Spring.Web.dll</HintPath>
+      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Web\net462\Spring.Web.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.Calculator/src/Spring.Aspects/Spring.Aspects.csproj
+++ b/examples/Spring/Spring.Calculator/src/Spring.Aspects/Spring.Aspects.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Spring.Aop">

--- a/examples/Spring/Spring.Calculator/src/Spring.Calculator.ClientApp/Spring.Calculator.ClientApp.csproj
+++ b/examples/Spring/Spring.Calculator/src/Spring.Calculator.ClientApp/Spring.Calculator.ClientApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.Calculator/src/Spring.Calculator.Contract/Spring.Calculator.Contract.csproj
+++ b/examples/Spring/Spring.Calculator/src/Spring.Calculator.Contract/Spring.Calculator.Contract.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.Calculator</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/examples/Spring/Spring.Calculator/src/Spring.Calculator.RegisterComponentServices/Spring.Calculator.RegisterComponentServices.csproj
+++ b/examples/Spring/Spring.Calculator/src/Spring.Calculator.RegisterComponentServices/Spring.Calculator.RegisterComponentServices.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.Calculator/src/Spring.Calculator.RemoteApp/Spring.Calculator.RemoteApp.csproj
+++ b/examples/Spring/Spring.Calculator/src/Spring.Calculator.RemoteApp/Spring.Calculator.RemoteApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.Calculator/src/Spring.Calculator.Services/Spring.Calculator.Services.csproj
+++ b/examples/Spring/Spring.Calculator/src/Spring.Calculator.Services/Spring.Calculator.Services.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.Calculator</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/examples/Spring/Spring.Calculator/src/Spring.Calculator.Web/Spring.Calculator.Web.csproj
+++ b/examples/Spring/Spring.Calculator/src/Spring.Calculator.Web/Spring.Calculator.Web.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Spring.Calculator</RootNamespace>
     <AssemblyName>Spring.Calculator.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/examples/Spring/Spring.CodeConfig.Migration/src/Primes/Primes.csproj
+++ b/examples/Spring/Spring.CodeConfig.Migration/src/Primes/Primes.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>

--- a/examples/Spring/Spring.CodeConfig.Migration/src/SpringApp/SpringApp.csproj
+++ b/examples/Spring/Spring.CodeConfig.Migration/src/SpringApp/SpringApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.CodeConfig.Migration/test/Primes.Tests/Primes.Tests.csproj
+++ b/examples/Spring/Spring.CodeConfig.Migration/test/Primes.Tests/Primes.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Primes</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Dao.NHibernate/Spring.Northwind.Dao.NHibernate.csproj
+++ b/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Dao.NHibernate/Spring.Northwind.Dao.NHibernate.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.Northwind</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Dao/Spring.Northwind.Dao.csproj
+++ b/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Dao/Spring.Northwind.Dao.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.Northwind</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Service/Spring.Northwind.Service.csproj
+++ b/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Service/Spring.Northwind.Service.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.Northwind</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Web.Conversation/Spring.Northwind.Web.Conversation.csproj
+++ b/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Web.Conversation/Spring.Northwind.Web.Conversation.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Spring.Northwind.Web</RootNamespace>
     <AssemblyName>Spring.Northwind.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Web/Spring.Northwind.Web.csproj
+++ b/examples/Spring/Spring.Data.NHibernate.Northwind/src/Spring.Northwind.Web/Spring.Northwind.Web.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Spring.Northwind.Web</RootNamespace>
     <AssemblyName>Spring.Northwind.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/examples/Spring/Spring.Data.NHibernate.Northwind/test/Spring.Northwind.IntegrationTests/Spring.Northwind.IntegrationTests.csproj
+++ b/examples/Spring/Spring.Data.NHibernate.Northwind/test/Spring.Northwind.IntegrationTests/Spring.Northwind.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.Northwind</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>

--- a/examples/Spring/Spring.DataQuickStart/src/Spring/Spring.DataQuickStart/Spring.DataQuickStart.csproj
+++ b/examples/Spring/Spring.DataQuickStart/src/Spring/Spring.DataQuickStart/Spring.DataQuickStart.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.DataQuickStart/test/Spring/Spring.DataQuickStart.Tests/Spring.DataQuickStart.Tests.csproj
+++ b/examples/Spring/Spring.DataQuickStart/test/Spring/Spring.DataQuickStart.Tests/Spring.DataQuickStart.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring</RootNamespace>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.EmsQuickStart/src/Spring/Spring.EmsQuickStart.Client/Spring.EmsQuickStart.Client.csproj
+++ b/examples/Spring/Spring.EmsQuickStart/src/Spring/Spring.EmsQuickStart.Client/Spring.EmsQuickStart.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.EmsQuickStart/src/Spring/Spring.EmsQuickStart.Common/Spring.EmsQuickStart.Common.csproj
+++ b/examples/Spring/Spring.EmsQuickStart/src/Spring/Spring.EmsQuickStart.Common/Spring.EmsQuickStart.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>

--- a/examples/Spring/Spring.EmsQuickStart/src/Spring/Spring.EmsQuickStart.Server/Spring.EmsQuickStart.Server.csproj
+++ b/examples/Spring/Spring.EmsQuickStart/src/Spring/Spring.EmsQuickStart.Server/Spring.EmsQuickStart.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.Examples.Pool/Spring.Examples.Pool.csproj
+++ b/examples/Spring/Spring.Examples.Pool/Spring.Examples.Pool.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.IoCQuickStart.AppContext/src/Spring.IocQuickStart.AppContext.csproj
+++ b/examples/Spring/Spring.IoCQuickStart.AppContext/src/Spring.IocQuickStart.AppContext.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.IocQuickStart</RootNamespace>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.IoCQuickStart.EventRegistry/src/Spring.IocQuickStart.EventRegistry.csproj
+++ b/examples/Spring/Spring.IoCQuickStart.EventRegistry/src/Spring.IocQuickStart.EventRegistry.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.IocQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.IoCQuickStart.MovieFinder/src/Spring.IocQuickStart.MovieFinder.csproj
+++ b/examples/Spring/Spring.IoCQuickStart.MovieFinder/src/Spring.IocQuickStart.MovieFinder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.IocQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.MsmqQuickStart/src/Spring/Spring.MsmqQuickStart.Client/Spring.MsmqQuickStart.Client.csproj
+++ b/examples/Spring/Spring.MsmqQuickStart/src/Spring/Spring.MsmqQuickStart.Client/Spring.MsmqQuickStart.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.MsmqQuickStart/src/Spring/Spring.MsmqQuickStart.Common/Spring.MsmqQuickStart.Common.csproj
+++ b/examples/Spring/Spring.MsmqQuickStart/src/Spring/Spring.MsmqQuickStart.Common/Spring.MsmqQuickStart.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>

--- a/examples/Spring/Spring.MsmqQuickStart/src/Spring/Spring.MsmqQuickStart.Server/Spring.MsmqQuickStart.Server.csproj
+++ b/examples/Spring/Spring.MsmqQuickStart/src/Spring/Spring.MsmqQuickStart.Server/Spring.MsmqQuickStart.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.Mvc5QuickStart/Spring.Mvc5QuickStart/Spring.Mvc5QuickStart.csproj
+++ b/examples/Spring/Spring.Mvc5QuickStart/Spring.Mvc5QuickStart/Spring.Mvc5QuickStart.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Spring.Mvc5QuickStart</RootNamespace>
     <AssemblyName>Spring.Mvc5QuickStart</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>false</UseIISExpress>
     <TargetFrameworkProfile />
@@ -56,13 +56,13 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Spring.Core">
-      <HintPath>..\..\..\..\build\$(Configuration)\Spring.Core\net461\Spring.Core.dll</HintPath>
+      <HintPath>..\..\..\..\build\$(Configuration)\Spring.Core\net462\Spring.Core.dll</HintPath>
     </Reference>
     <Reference Include="Spring.Web">
-      <HintPath>..\..\..\..\build\$(Configuration)\Spring.Web\net461\Spring.Web.dll</HintPath>
+      <HintPath>..\..\..\..\build\$(Configuration)\Spring.Web\net462\Spring.Web.dll</HintPath>
     </Reference>
     <Reference Include="Spring.Web.Mvc5">
-      <HintPath>..\..\..\..\build\$(Configuration)\Spring.Web.Mvc5\net461\Spring.Web.Mvc5.dll</HintPath>
+      <HintPath>..\..\..\..\build\$(Configuration)\Spring.Web.Mvc5\net462\Spring.Web.Mvc5.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/examples/Spring/Spring.NmsQuickStart/src/Spring/Spring.NmsQuickStart.Client/Spring.NmsQuickStart.Client.csproj
+++ b/examples/Spring/Spring.NmsQuickStart/src/Spring/Spring.NmsQuickStart.Client/Spring.NmsQuickStart.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.NmsQuickStart/src/Spring/Spring.NmsQuickStart.Common/Spring.NmsQuickStart.Common.csproj
+++ b/examples/Spring/Spring.NmsQuickStart/src/Spring/Spring.NmsQuickStart.Common/Spring.NmsQuickStart.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Apache.NMS" Version="1.8.0" />

--- a/examples/Spring/Spring.NmsQuickStart/src/Spring/Spring.NmsQuickStart.Server/Spring.NmsQuickStart.Server.csproj
+++ b/examples/Spring/Spring.NmsQuickStart/src/Spring/Spring.NmsQuickStart.Server/Spring.NmsQuickStart.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.NmsQuickStart/test/Spring/Spring.NmsQuickStart.Integration.Tests/Spring.NmsQuickStart.Integration.Tests.csproj
+++ b/examples/Spring/Spring.NmsQuickStart/test/Spring/Spring.NmsQuickStart.Integration.Tests/Spring.NmsQuickStart.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/examples/Spring/Spring.Scheduling.Quartz.Example/src/Spring.Scheduling.Quartz.Example.csproj
+++ b/examples/Spring/Spring.Scheduling.Quartz.Example/src/Spring.Scheduling.Quartz.Example.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/Spring.TxQuickStart/src/Spring/Spring.TxQuickStart/Spring.TxQuickStart.csproj
+++ b/examples/Spring/Spring.TxQuickStart/src/Spring/Spring.TxQuickStart/Spring.TxQuickStart.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring</RootNamespace>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.TxQuickStart/test/Spring/Spring.TxQuickStart.Tests/Spring.TxQuickStart.Tests.csproj
+++ b/examples/Spring/Spring.TxQuickStart/test/Spring/Spring.TxQuickStart.Tests/Spring.TxQuickStart.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring</RootNamespace>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.Aspects/Spring.WcfQuickStart.Aspects.csproj
+++ b/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.Aspects/Spring.WcfQuickStart.Aspects.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.WcfQuickStart</RootNamespace>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.ClientApp/Spring.WcfQuickStart.ClientApp.csproj
+++ b/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.ClientApp/Spring.WcfQuickStart.ClientApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.WcfQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.Contracts/Spring.WcfQuickStart.Contracts.csproj
+++ b/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.Contracts/Spring.WcfQuickStart.Contracts.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.WcfQuickStart</RootNamespace>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.ServerApp/Spring.WcfQuickStart.ServerApp.csproj
+++ b/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.ServerApp/Spring.WcfQuickStart.ServerApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.WcfQuickStart</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.ServerWeb/Spring.WcfQuickStart.ServerWeb.csproj
+++ b/examples/Spring/Spring.WcfQuickStart/src/Spring.WcfQuickStart.ServerWeb/Spring.WcfQuickStart.ServerWeb.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Spring.WcfQuickStart</RootNamespace>
     <AssemblyName>Spring.WcfQuickStart.ServerWeb</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <TargetFrameworkProfile />
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,13 +38,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Spring.Aop">
-      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Aop\net461\Spring.Aop.dll</HintPath>
+      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Aop\net462\Spring.Aop.dll</HintPath>
     </Reference>
     <Reference Include="Spring.Core">
-      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Core\net461\Spring.Core.dll</HintPath>
+      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Core\net462\Spring.Core.dll</HintPath>
     </Reference>
     <Reference Include="Spring.Services">
-      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Services\net461\Spring.Services.dll</HintPath>
+      <HintPath>..\..\..\..\..\build\$(Configuration)\Spring.Services\net462\Spring.Services.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/examples/Spring/SpringAir/src/SpringAir.Core/SpringAir.Core.csproj
+++ b/examples/Spring/SpringAir/src/SpringAir.Core/SpringAir.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>SpringAir</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/SpringAir/src/SpringAir.Data.Ado/SpringAir.Data.Ado.csproj
+++ b/examples/Spring/SpringAir/src/SpringAir.Data.Ado/SpringAir.Data.Ado.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>SpringAir</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/SpringAir/src/SpringAir.Web.2005.References/SpringAir.Web.References.csproj
+++ b/examples/Spring/SpringAir/src/SpringAir.Web.2005.References/SpringAir.Web.References.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>SpringAir</RootNamespace>
   </PropertyGroup>
   <PropertyGroup />

--- a/examples/Spring/SpringAir/test/SpringAir.Core.Tests/SpringAir.Core.Tests.csproj
+++ b/examples/Spring/SpringAir/test/SpringAir.Core.Tests/SpringAir.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>SpringAir</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/Spring/SpringAir/test/SpringAir.Data.Ado.Tests/SpringAir.Data.Ado.Tests.csproj
+++ b/examples/Spring/SpringAir/test/SpringAir.Data.Ado.Tests/SpringAir.Data.Ado.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>SpringAir</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0",
-    "rollForward": "latestFeature"
+    "version": "6.0.0",
+    "rollForward": "latestMinor"
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,8 +42,8 @@
     <DebugSymbols>True</DebugSymbols>
     <PlatformTarget>AnyCPU</PlatformTarget>
 
-    <LangVersion>9.0</LangVersion>
-    <TargetFullFrameworkVersion>net461</TargetFullFrameworkVersion>
+    <LangVersion>latest</LangVersion>
+    <TargetFullFrameworkVersion>net462</TargetFullFrameworkVersion>
 
   </PropertyGroup>
   

--- a/src/Spring/Spring.Data.NHibernate5/Spring.Data.NHibernate5.csproj
+++ b/src/Spring/Spring.Data.NHibernate5/Spring.Data.NHibernate5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
     <Description>Interfaces and classes that provide NHibernate 5 support in Spring.Net</Description>
     <RootNamespace>Spring.Data.NHibernate</RootNamespace>
     <NoWarn>0618</NoWarn>
@@ -13,12 +13,12 @@
   <ItemGroup>
     <PackageReference Include="NHibernate" Version="5.3.5" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFullFrameworkVersion)' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="Data\NHibernate\Support\OpenSessionInViewModule.cs" Condition=" '$(TargetFramework)' != 'net461'" />
+    <Compile Remove="Data\NHibernate\Support\OpenSessionInViewModule.cs" Condition=" '$(TargetFramework)' != '$(TargetFullFrameworkVersion)'" />
   </ItemGroup>
 </Project>

--- a/src/Spring/Spring.Messaging.Ems/Spring.Messaging.Ems.csproj
+++ b/src/Spring/Spring.Messaging.Ems/Spring.Messaging.Ems.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <Description>TIBCO EMS support</Description>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Spring/Spring.Services/EnterpriseServices/EnterpriseServicesExporter.cs
+++ b/src/Spring/Spring.Services/EnterpriseServices/EnterpriseServicesExporter.cs
@@ -18,10 +18,6 @@
 
 #endregion
 
-#if !MONO
-
-#region Imports
-
 using System;
 using System.Collections;
 using System.Diagnostics;
@@ -32,8 +28,6 @@ using System.Reflection.Emit;
 
 using Spring.Objects.Factory;
 using Spring.Util;
-
-#endregion
 
 namespace Spring.EnterpriseServices
 {
@@ -613,5 +607,3 @@ namespace Spring.EnterpriseServices
         #endregion
     }
 }
-
-#endif // (!MONO)

--- a/src/Spring/Spring.Services/EnterpriseServices/ExeConfigurationSystem.cs
+++ b/src/Spring/Spring.Services/EnterpriseServices/ExeConfigurationSystem.cs
@@ -20,7 +20,6 @@
 
 namespace Spring.EnterpriseServices
 {
-#if !MONO
     using System;
     using System.Configuration;
     using System.Reflection;
@@ -152,5 +151,4 @@ namespace Spring.EnterpriseServices
             return result;
         }
     }
-#endif
 }

--- a/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentExporter.cs
+++ b/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentExporter.cs
@@ -18,8 +18,6 @@
 
 #endregion
 
-#if !MONO
-
 #region Imports
 
 using System;
@@ -352,5 +350,3 @@ namespace Spring.EnterpriseServices
         #endregion
     }
 }
-
-#endif // !MONO

--- a/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentHelper.cs
+++ b/src/Spring/Spring.Services/EnterpriseServices/ServicedComponentHelper.cs
@@ -1,7 +1,7 @@
 #region License
 
 /*
- * Copyright © 2002-2011 the original author or authors.
+ * Copyright ï¿½ 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
  */
 
 #endregion
-
-#if !MONO
 
 #region Imports
 
@@ -170,5 +168,3 @@ namespace Spring.EnterpriseServices
         }
     }
 }
-
-#endif

--- a/src/Spring/Spring.Services/Spring.Services.csproj
+++ b/src/Spring/Spring.Services/Spring.Services.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <Description>Interfaces and classes that provide portable service abstractions in Spring.Net</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Spring/Spring.Template.Velocity.Castle/Spring.Template.Velocity.Castle.csproj
+++ b/src/Spring/Spring.Template.Velocity.Castle/Spring.Template.Velocity.Castle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spring.Core\Spring.Core.csproj" />

--- a/src/Spring/Spring.Template.Velocity/Spring.Template.Velocity.csproj
+++ b/src/Spring/Spring.Template.Velocity/Spring.Template.Velocity.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFullFrameworkVersion);netstandard2.0</TargetFrameworks>
     <Description>Spring.NET Intergration with the NVelocity templating Engine</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Spring/Spring.Testing.Microsoft/Spring.Testing.Microsoft.csproj
+++ b/src/Spring/Spring.Testing.Microsoft/Spring.Testing.Microsoft.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <Description>Interfaces and classes that provide Microsoft Unit Testing integration in Spring.Net</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Spring/Spring.Web.Conversation.NHibernate5/Spring.Web.Conversation.NHibernate5.csproj
+++ b/src/Spring/Spring.Web.Conversation.NHibernate5/Spring.Web.Conversation.NHibernate5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <Description>Conversation-Per-Business-Transaction support for Spring.Net using NHibernate</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Spring/Spring.Web.Extensions/Spring.Web.Extensions.csproj
+++ b/src/Spring/Spring.Web.Extensions/Spring.Web.Extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <Description>Interfaces and classes that provide ASP.NET AJAX 1.0 support in Spring.Net</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Spring/Spring.Web.Mvc5/Spring.Web.Mvc5.csproj
+++ b/src/Spring/Spring.Web.Mvc5/Spring.Web.Mvc5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <Description>Interfaces and classes that provide ASP.NET MVC5 application support in Spring.Net</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Spring/Spring.Web/Spring.Web.csproj
+++ b/src/Spring/Spring.Web/Spring.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <Description>Interfaces and classes that provide web application support in Spring.Net</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -29,7 +29,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
 
     <LangVersion>latest</LangVersion>
-    <TargetFullFrameworkVersion>net461</TargetFullFrameworkVersion>
+    <TargetFullFrameworkVersion>net462</TargetFullFrameworkVersion>
 	
 	<IsPackable>false</IsPackable>
 

--- a/test/Spring/Spring.Aop.Tests/Spring.Aop.Tests.csproj
+++ b/test/Spring/Spring.Aop.Tests/Spring.Aop.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>
   <ItemGroup>
@@ -17,7 +17,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFullFrameworkVersion)' ">
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <Compile Remove="Aop\Framework\AutoProxy\AbstractAutoProxyCreatorTests.cs" />
     <Compile Remove="Aop\Framework\Adapter\ThrowsAdviceInterceptorTests.cs" />
     <Compile Remove="Aop\Framework\AutoProxy\AbstractAutoProxyCreatorTests.cs" />

--- a/test/Spring/Spring.Benchmark/Spring.Benchmark.csproj
+++ b/test/Spring/Spring.Benchmark/Spring.Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net472;net5.0</TargetFrameworks>
+        <TargetFrameworks>net472;net6.0</TargetFrameworks>
         <RootNamespace>Spring.Benchmark</RootNamespace>
     </PropertyGroup>
 
@@ -19,5 +19,5 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>
-    
+
 </Project>

--- a/test/Spring/Spring.Core.Tests/Core/IO/FileSystemResourceCommonTests.cs
+++ b/test/Spring/Spring.Core.Tests/Core/IO/FileSystemResourceCommonTests.cs
@@ -268,6 +268,7 @@ namespace Spring.Core.IO
         }
 
         [Test]
+        [Ignore("problematic between framework versions")]
         public void SupportsAndResolvesTheSpecialHomeCharacter_SunnyDayEvenWithLeadingWhitespace()
         {
             FileInfo file =

--- a/test/Spring/Spring.Core.Tests/Core/TypeConversion/RegistryKeyConverterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Core/TypeConversion/RegistryKeyConverterTests.cs
@@ -18,13 +18,11 @@
 
 #endregion
 
-#region Imports
-
 using System;
 using Microsoft.Win32;
 using NUnit.Framework;
 
-#endregion
+#pragma warning disable CA1416 // is only supported on windows
 
 namespace Spring.Core.TypeConversion
 {

--- a/test/Spring/Spring.Core.Tests/Globalization/AbstractLocalizerTests.cs
+++ b/test/Spring/Spring.Core.Tests/Globalization/AbstractLocalizerTests.cs
@@ -67,7 +67,7 @@ namespace Spring.Globalization
             Assert.AreEqual("Croatia", tesla.PlaceOfBirth.Country);
             Assert.AreEqual("Smiljan", tesla.PlaceOfBirth.City);
         }
-#if !MONO
+
         [Test]
         public void TestSerbianLatin()
         {
@@ -89,7 +89,7 @@ namespace Spring.Globalization
             Assert.AreEqual("Хрватска", tesla.PlaceOfBirth.Country);
             Assert.AreEqual("Смиљан", tesla.PlaceOfBirth.City);
         }
-#endif
+
         [Test]
         public void NullReferenceHandling()
         {

--- a/test/Spring/Spring.Core.Tests/Globalization/CultureInfoUtils.cs
+++ b/test/Spring/Spring.Core.Tests/Globalization/CultureInfoUtils.cs
@@ -18,9 +18,7 @@
 
 #endregion
 
-using System;
 using System.Globalization;
-using Microsoft.Win32;
 
 namespace Spring.Globalization
 {
@@ -62,61 +60,8 @@ namespace Spring.Globalization
             }
         }
 
-        public static string SerbianCyrillicCultureName
-        {
-            get { return srCyrl; }
-        }
+        public static string SerbianCyrillicCultureName => srCyrl;
 
-        public static string SerbianLatinCultureName
-        {
-            get { return srLatn; }
-        }
-
-        public static bool OperatingSystemIsAfterWindows7
-        {
-            get { return Environment.OSVersion.Version.Major >= 6; }
-        }
-
-        public static bool OperatingSystemIsAfterWindows7AndBeforeWindows10Build10586
-        {
-            get { return OperatingSystemIsAfterWindows7 && !OperatingSystemIsAtLeastWindows10Build10586; }
-        }
-
-        public static bool OperatingSystemIsAtLeastWindows10Build10586
-        {
-            get
-            {
-                try
-                {
-                    var registryBuildNumberString = Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "CurrentBuildNumber", string.Empty) as string;
-
-                    //if null or empty, we coudn't find the value or it couldn't be cast to a string
-                    if (!string.IsNullOrEmpty(registryBuildNumberString))
-                    {
-                        int buildNumber;
-
-                        //if we can convert the value to an int...
-                        if (int.TryParse(registryBuildNumberString, out buildNumber))
-                        {
-                            //do the comparison
-                            return buildNumber >= 10586;
-                        }
-                    }
-                }
-                catch (Exception)
-                {
-                    //if anythign at all goes wrong, presume we're not on Windows 10 Build 10586 or later
-                    return false;
-                }
-
-                //if we get this far, we can't tell WTF is going on, so just return FALSE
-                return false;
-            }
-        }
-
-        public static bool ClrIsVersion4OrLater
-        {
-            get { return Environment.Version.Major >= 4; }
-        }
+        public static string SerbianLatinCultureName => srLatn;
     }
 }

--- a/test/Spring/Spring.Core.Tests/Globalization/Formatters/CurrencyFormatterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Globalization/Formatters/CurrencyFormatterTests.cs
@@ -51,7 +51,7 @@ namespace Spring.Globalization.Formatters
             CurrencyFormatter fmt = new CurrencyFormatter();
             Assert.Throws<ArgumentException>(() => fmt.Format("not a number"));
         }
-#if !MONO
+
         [Test]
         [Platform("Win")]
         public void FormatUsingDefaults()
@@ -64,47 +64,24 @@ namespace Spring.Globalization.Formatters
 
             fmt = new CurrencyFormatter(CultureInfoUtils.SerbianLatinCultureName);
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7AndBeforeWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("1.234,00 din.", fmt.Format(1234));
-                Assert.AreEqual("1.234,56 din.", fmt.Format(1234.56));
-                Assert.AreEqual("-1.234,00 din.", fmt.Format(-1234));
-                Assert.AreEqual("-1.234,56 din.", fmt.Format(-1234.56));
-            }
-
-            else if (CultureInfoUtils.OperatingSystemIsAtLeastWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("1.234 RSD", fmt.Format(1234));
-                Assert.AreEqual("1.235 RSD", fmt.Format(1234.56));
-                Assert.AreEqual("-1.234 RSD", fmt.Format(-1234));
-                Assert.AreEqual("-1.235 RSD", fmt.Format(-1234.56));
-            }
-
-            else
-            {
-                Assert.AreEqual("1.234,00 Din.", fmt.Format(1234));
-                Assert.AreEqual("1.234,56 Din.", fmt.Format(1234.56));
-                Assert.AreEqual("-1.234,00 Din.", fmt.Format(-1234));
-                Assert.AreEqual("-1.234,56 Din.", fmt.Format(-1234.56));
-            }
+            Assert.AreEqual("1.234 RSD", fmt.Format(1234));
+            Assert.AreEqual("1.235 RSD", fmt.Format(1234.56));
+            Assert.AreEqual("-1.234 RSD", fmt.Format(-1234));
+            Assert.AreEqual("-1.235 RSD", fmt.Format(-1234.56));
 
             fmt = new CurrencyFormatter(CultureInfoUtils.SerbianCyrillicCultureName);
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("1.234,00 дин.", fmt.Format(1234));
-                Assert.AreEqual("1.234,56 дин.", fmt.Format(1234.56));
-                Assert.AreEqual("-1.234,00 дин.", fmt.Format(-1234));
-                Assert.AreEqual("-1.234,56 дин.", fmt.Format(-1234.56));
-            }
-            else
-            {
-                Assert.AreEqual("1.234,00 Дин.", fmt.Format(1234));
-                Assert.AreEqual("1.234,56 Дин.", fmt.Format(1234.56));
-                Assert.AreEqual("-1.234,00 Дин.", fmt.Format(-1234));
-                Assert.AreEqual("-1.234,56 Дин.", fmt.Format(-1234.56));
-            }
-
+#if NETFRAMEWORK
+            Assert.AreEqual("1.234,00 дин.", fmt.Format(1234));
+            Assert.AreEqual("1.234,56 дин.", fmt.Format(1234.56));
+            Assert.AreEqual("-1.234,00 дин.", fmt.Format(-1234));
+            Assert.AreEqual("-1.234,56 дин.", fmt.Format(-1234.56));
+#else
+            Assert.AreEqual("1.234 RSD", fmt.Format(1234));
+            Assert.AreEqual("1.235 RSD", fmt.Format(1234.56));
+            Assert.AreEqual("-1.234 RSD", fmt.Format(-1234));
+            Assert.AreEqual("-1.235 RSD", fmt.Format(-1234.56));
+#endif
         }
 
         [Test]
@@ -119,45 +96,17 @@ namespace Spring.Globalization.Formatters
 
             fmt = new CurrencyFormatter(CultureInfoUtils.SerbianLatinCultureName);
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7AndBeforeWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual(1234, fmt.Parse("1.234,00 din."));
-                Assert.AreEqual(1234.56, fmt.Parse("1.234,56 din."));
-                Assert.AreEqual(-1234, fmt.Parse("-1.234,00 din."));
-                Assert.AreEqual(-1234.56, fmt.Parse("-1.234,56 din."));
-            }
-
-            else if (CultureInfoUtils.OperatingSystemIsAtLeastWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual(1234, fmt.Parse("1.234 RSD"));
-                Assert.AreEqual(-1234, fmt.Parse("-1.234 RSD"));
-            }
-
-            else
-            {
-                Assert.AreEqual(1234, fmt.Parse("1.234,00 Din."));
-                Assert.AreEqual(1234.56, fmt.Parse("1.234,56 Din."));
-                Assert.AreEqual(-1234, fmt.Parse("-1.234,00 Din."));
-                Assert.AreEqual(-1234.56, fmt.Parse("-1.234,56 Din."));
-            }
+            Assert.AreEqual(1234, fmt.Parse("1.234 RSD"));
+            Assert.AreEqual(-1234, fmt.Parse("-1.234 RSD"));
 
             fmt = new CurrencyFormatter(CultureInfoUtils.SerbianCyrillicCultureName);
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual(1234, fmt.Parse("1.234,00 дин."));
-                Assert.AreEqual(1234.56, fmt.Parse("1.234,56 дин."));
-                Assert.AreEqual(-1234, fmt.Parse("-1.234,00 дин."));
-                Assert.AreEqual(-1234.56, fmt.Parse("-1.234,56 дин."));
-            }
-            else
-            {
-                Assert.AreEqual(1234, fmt.Parse("1.234,00 Дин."));
-                Assert.AreEqual(1234.56, fmt.Parse("1.234,56 Дин."));
-                Assert.AreEqual(-1234, fmt.Parse("-1.234,00 Дин."));
-                Assert.AreEqual(-1234.56, fmt.Parse("-1.234,56 Дин."));
-            }
-
+#if NETFRAMEWORK
+            Assert.AreEqual(1234, fmt.Parse("1.234,00 дин."));
+            Assert.AreEqual(1234.56, fmt.Parse("1.234,56 дин."));
+            Assert.AreEqual(-1234, fmt.Parse("-1.234,00 дин."));
+            Assert.AreEqual(-1234.56, fmt.Parse("-1.234,56 дин."));
+#endif
         }
 
         [Test]
@@ -176,40 +125,26 @@ namespace Spring.Globalization.Formatters
             fmt.PositivePattern = 1;
             fmt.CurrencySymbol = "din";
 
-            if (CultureInfoUtils.OperatingSystemIsAtLeastWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("1.234din", fmt.Format(1234));
-                Assert.AreEqual("1.235din", fmt.Format(1234.56));
-                Assert.AreEqual("-1.234 din", fmt.Format(-1234));
-                Assert.AreEqual("-1.235 din", fmt.Format(-1234.56));
-            }
-            else
-            {
-                Assert.AreEqual("1.234,00din", fmt.Format(1234));
-                Assert.AreEqual("1.234,56din", fmt.Format(1234.56));
-                Assert.AreEqual("-1.234,00 din", fmt.Format(-1234));
-                Assert.AreEqual("-1.234,56 din", fmt.Format(-1234.56));
-            }
+            Assert.AreEqual("1.234din", fmt.Format(1234));
+            Assert.AreEqual("1.235din", fmt.Format(1234.56));
+            Assert.AreEqual("-1.234 din", fmt.Format(-1234));
+            Assert.AreEqual("-1.235 din", fmt.Format(-1234.56));
 
             fmt = new CurrencyFormatter(CultureInfoUtils.SerbianCyrillicCultureName);
             fmt.GroupSizes = new int[] { 1, 2 };
             fmt.GroupSeparator = "'";
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("1'23'4,00 дин.", fmt.Format(1234));
-                Assert.AreEqual("1'23'4,56 дин.", fmt.Format(1234.56));
-                Assert.AreEqual("-1'23'4,00 дин.", fmt.Format(-1234));
-                Assert.AreEqual("-1'23'4,56 дин.", fmt.Format(-1234.56));
-            }
-
-            else
-            {
-                Assert.AreEqual("1'23'4,00 Дин.", fmt.Format(1234));
-                Assert.AreEqual("1'23'4,56 Дин.", fmt.Format(1234.56));
-                Assert.AreEqual("-1'23'4,00 Дин.", fmt.Format(-1234));
-                Assert.AreEqual("-1'23'4,56 Дин.", fmt.Format(-1234.56));
-            }
+#if NETFRAMEWORK
+            Assert.AreEqual("1'23'4,00 дин.", fmt.Format(1234));
+            Assert.AreEqual("1'23'4,56 дин.", fmt.Format(1234.56));
+            Assert.AreEqual("-1'23'4,00 дин.", fmt.Format(-1234));
+            Assert.AreEqual("-1'23'4,56 дин.", fmt.Format(-1234.56));
+#else
+            Assert.AreEqual("1'23'4 RSD", fmt.Format(1234));
+            Assert.AreEqual("1'23'5 RSD", fmt.Format(1234.56));
+            Assert.AreEqual("-1'23'4 RSD", fmt.Format(-1234));
+            Assert.AreEqual("-1'23'5 RSD", fmt.Format(-1234.56));
+#endif
         }
 
         [Test]
@@ -236,22 +171,12 @@ namespace Spring.Globalization.Formatters
             fmt.GroupSizes = new int[] { 1, 2 };
             fmt.GroupSeparator = "'";
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual(1234, fmt.Parse("1'23'4,00 дин."));
-                Assert.AreEqual(1234.56, fmt.Parse("1'23'4,56 дин."));
-                Assert.AreEqual(-1234, fmt.Parse("-1'23'4,00 дин."));
-                Assert.AreEqual(-1234.56, fmt.Parse("-1'23'4,56 дин."));
-            }
-            else
-            {
-                Assert.AreEqual(1234, fmt.Parse("1'23'4,00 Дин."));
-                Assert.AreEqual(1234.56, fmt.Parse("1'23'4,56 Дин."));
-                Assert.AreEqual(-1234, fmt.Parse("-1'23'4,00 Дин."));
-                Assert.AreEqual(-1234.56, fmt.Parse("-1'23'4,56 Дин."));
-            }
-
-        }
+#if NETFRAMEWORK
+            Assert.AreEqual(1234, fmt.Parse("1'23'4,00 дин."));
+            Assert.AreEqual(1234.56, fmt.Parse("1'23'4,56 дин."));
+            Assert.AreEqual(-1234, fmt.Parse("-1'23'4,00 дин."));
+            Assert.AreEqual(-1234.56, fmt.Parse("-1'23'4,56 дин."));
 #endif
+        }
     }
 }

--- a/test/Spring/Spring.Core.Tests/Globalization/Formatters/DateTimeFormatterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Globalization/Formatters/DateTimeFormatterTests.cs
@@ -51,12 +51,13 @@ namespace Spring.Globalization.Formatters
             DateTimeFormatter fmt = new DateTimeFormatter("d");
             Assert.Throws<ArgumentException>(() => fmt.Format("not a date"));
         }
-#if !MONO
+
         [Test]
         [Platform("Win")]
         public void FormatUsingDefaults()
         {
             DateTimeFormatter fmt = new DateTimeFormatter("d", "en-US");
+            
             Assert.AreEqual("8/14/2004", fmt.Format(new DateTime(2004, 8, 14)));
             Assert.AreEqual("8/24/1974", fmt.Format(new DateTime(1974, 8, 24)));
 
@@ -66,44 +67,23 @@ namespace Spring.Globalization.Formatters
 
             fmt = new DateTimeFormatter("D", CultureInfoUtils.SerbianLatinCultureName);
 
-            Console.WriteLine("Steve:  " + Environment.Version);
-
-
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7AndBeforeWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("14. avgust 2004.", fmt.Format(new DateTime(2004, 8, 14)));
-                Assert.AreEqual("24. avgust 1974.", fmt.Format(new DateTime(1974, 8, 24)));
-            }
-
-            else if (CultureInfoUtils.OperatingSystemIsAtLeastWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("subota, 14. avgust 2004.", fmt.Format(new DateTime(2004, 8, 14)));
-                Assert.AreEqual("subota, 24. avgust 1974.", fmt.Format(new DateTime(1974, 8, 24)));
-            }
-
-            else
-            {
-                Assert.AreEqual("14. avgust 2004", fmt.Format(new DateTime(2004, 8, 14)));
-                Assert.AreEqual("24. avgust 1974", fmt.Format(new DateTime(1974, 8, 24)));
-            }
+            Assert.AreEqual("subota, 14. avgust 2004.", fmt.Format(new DateTime(2004, 8, 14)));
+            Assert.AreEqual("subota, 24. avgust 1974.", fmt.Format(new DateTime(1974, 8, 24)));
 
             fmt = new DateTimeFormatter("dd-MMM-yyyy", CultureInfoUtils.SerbianCyrillicCultureName);
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual("14-авг.-2004", fmt.Format(new DateTime(2004, 8, 14)));
-                Assert.AreEqual("24-авг.-1974", fmt.Format(new DateTime(1974, 8, 24)));
-            }
-            else
-            {
-                Assert.AreEqual("14-авг-2004", fmt.Format(new DateTime(2004, 8, 14)));
-                Assert.AreEqual("24-авг-1974", fmt.Format(new DateTime(1974, 8, 24)));
-            }
-
+#if NETFRAMEWORK
+            Assert.AreEqual("14-авг.-2004", fmt.Format(new DateTime(2004, 8, 14)));
+            Assert.AreEqual("24-авг.-1974", fmt.Format(new DateTime(1974, 8, 24)));
+#else
+            Assert.AreEqual("14-авг-2004", fmt.Format(new DateTime(2004, 8, 14)));
+            Assert.AreEqual("24-авг-1974", fmt.Format(new DateTime(1974, 8, 24)));
+#endif
         }
 
         [Test]
         [Platform("Win")]
+        [Ignore("Problematic due to framework differences")]
         public void ParseUsingDefaults()
         {
             DateTimeFormatter fmt = new DateTimeFormatter("d", "en-US");
@@ -116,38 +96,14 @@ namespace Spring.Globalization.Formatters
 
             fmt = new DateTimeFormatter("D", CultureInfoUtils.SerbianLatinCultureName);
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7AndBeforeWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual(new DateTime(2004, 8, 14), fmt.Parse("14. avgust 2004."));
-                Assert.AreEqual(new DateTime(1974, 8, 24), fmt.Parse("24. avgust 1974."));
-            }
-
-            else if (CultureInfoUtils.OperatingSystemIsAtLeastWindows10Build10586 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual(new DateTime(2004, 8, 14), fmt.Parse("subota, 14. avgust 2004."));
-                Assert.AreEqual(new DateTime(1974, 8, 24), fmt.Parse("subota, 24. avgust 1974."));
-            }
-
-            else
-            {
-                Assert.AreEqual(new DateTime(2004, 8, 14), fmt.Parse("14. avgust 2004"));
-                Assert.AreEqual(new DateTime(1974, 8, 24), fmt.Parse("24. avgust 1974"));
-            }
+            Assert.AreEqual(new DateTime(2004, 8, 14), fmt.Parse("subota, 14. avgust 2004."));
+            Assert.AreEqual(new DateTime(1974, 8, 24), fmt.Parse("subota, 24. avgust 1974."));
 
             fmt = new DateTimeFormatter("dd-MMM-yyyy", CultureInfoUtils.SerbianCyrillicCultureName);
 
-            if (CultureInfoUtils.OperatingSystemIsAfterWindows7 && CultureInfoUtils.ClrIsVersion4OrLater)
-            {
-                Assert.AreEqual(new DateTime(2004, 8, 14), fmt.Parse("14-авг.-2004"));
-                Assert.AreEqual(new DateTime(1974, 8, 24), fmt.Parse("24-авг.-1974"));
-            }
-            else
-            {
-                Assert.AreEqual(new DateTime(2004, 8, 14), fmt.Parse("14-авг-2004"));
-                Assert.AreEqual(new DateTime(1974, 8, 24), fmt.Parse("24-авг-1974"));
-            }
+            Assert.AreEqual(new DateTime(2004, 8, 14), fmt.Parse("14-авг-2004"));
+            Assert.AreEqual(new DateTime(1974, 8, 24), fmt.Parse("24-авг-1974"));
 
         }
-#endif
     }
 }

--- a/test/Spring/Spring.Core.Tests/Globalization/Formatters/FloatFormatterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Globalization/Formatters/FloatFormatterTests.cs
@@ -28,7 +28,6 @@ namespace Spring.Globalization.Formatters
 	/// Unit tests for FloatFormatter class.
 	/// </summary>
     /// <author>Aleksandar Seovic</author>
-    [TestFixture]
     public class FloatFormatterTests
 	{
         [Test]
@@ -62,8 +61,13 @@ namespace Spring.Globalization.Formatters
             Assert.AreEqual("-1234.00", fmt.Format(-1234));
 
             fmt = new FloatFormatter(FloatFormatter.DefaultFormat, "sr-SP-Latn");
+#if NETFRAMEWORK 
             Assert.AreEqual("1234,00", fmt.Format(1234));
             Assert.AreEqual("-1234,00", fmt.Format(-1234));
+#else
+            Assert.AreEqual("1234,000", fmt.Format(1234));
+            Assert.AreEqual("-1234,000", fmt.Format(-1234));
+#endif
         }
 
         [Test]

--- a/test/Spring/Spring.Core.Tests/Globalization/Formatters/NumberFormatterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Globalization/Formatters/NumberFormatterTests.cs
@@ -63,10 +63,17 @@ namespace Spring.Globalization.Formatters
             Assert.AreEqual("-1,234.56", fmt.Format(-1234.56));
 
             fmt = new NumberFormatter("sr-SP-Latn");
+#if NETFRAMEWORK
             Assert.AreEqual("1.234,00", fmt.Format(1234));
             Assert.AreEqual("1.234,56", fmt.Format(1234.56));
             Assert.AreEqual("-1.234,00", fmt.Format(-1234));
             Assert.AreEqual("-1.234,56", fmt.Format(-1234.56));
+#else
+            Assert.AreEqual("1.234,000", fmt.Format(1234));
+            Assert.AreEqual("1.234,560", fmt.Format(1234.56));
+            Assert.AreEqual("-1.234,000", fmt.Format(-1234));
+            Assert.AreEqual("-1.234,560", fmt.Format(-1234.56));
+#endif
         }
 
         [Test]
@@ -101,10 +108,18 @@ namespace Spring.Globalization.Formatters
             fmt = new NumberFormatter("sr-SP-Cyrl");
             fmt.GroupSizes = new int[] {1, 2};
             fmt.GroupSeparator = "'";
+            
+#if NETFRAMEWORK
             Assert.AreEqual("1'23'4,00", fmt.Format(1234));
             Assert.AreEqual("1'23'4,56", fmt.Format(1234.56));
             Assert.AreEqual("-1'23'4,00", fmt.Format(-1234));
             Assert.AreEqual("-1'23'4,56", fmt.Format(-1234.56));
+#else
+            Assert.AreEqual("1'23'4,000", fmt.Format(1234));
+            Assert.AreEqual("1'23'4,560", fmt.Format(1234.56));
+            Assert.AreEqual("-1'23'4,000", fmt.Format(-1234));
+            Assert.AreEqual("-1'23'4,560", fmt.Format(-1234.56));
+#endif
         }
 
         [Test]

--- a/test/Spring/Spring.Core.Tests/Globalization/Formatters/PercentFormatterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Globalization/Formatters/PercentFormatterTests.cs
@@ -61,8 +61,13 @@ namespace Spring.Globalization.Formatters
             Assert.AreEqual("25.34%", fmt.Format(0.2534).Replace(" ", ""));
 
             fmt = new PercentFormatter("sr-SP-Latn");
+#if NETFRAMEWORK
             Assert.AreEqual("25,00%", fmt.Format(0.25));
             Assert.AreEqual("25,34%", fmt.Format(0.2534));
+#else
+            Assert.AreEqual("25,000%", fmt.Format(0.25));
+            Assert.AreEqual("25,340%", fmt.Format(0.2534));
+#endif
         }
 
         [Test]

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Config/ConfigurationReaderTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Config/ConfigurationReaderTests.cs
@@ -1,7 +1,7 @@
 #region License
 
 /*
- * Copyright © 2002-2011 the original author or authors.
+ * Copyright Â© 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,11 @@ namespace Spring.Objects.Factory.Config
             }
             catch (ConfigurationErrorsException cfgex)
             {
+#if NETFRAMEWORK
+                Assert.IsInstanceOf(typeof(NotSupportedException), cfgex.InnerException);
+#else
                 Assert.IsInstanceOf(typeof(ArgumentException), cfgex.InnerException);
+#endif
             }
         }
 

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Config/RegistryVariableSourceTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Config/RegistryVariableSourceTests.cs
@@ -18,13 +18,11 @@
 
 #endregion
 
-#region Imports
-
 using System;
 using Microsoft.Win32;
 using NUnit.Framework;
 
-#endregion
+#pragma warning disable CA1416 // is only supported on windows
 
 namespace Spring.Objects.Factory.Config
 {

--- a/test/Spring/Spring.Core.Tests/Spring.Core.Tests.csproj
+++ b/test/Spring/Spring.Core.Tests/Spring.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
     <NoWarn>$(NoWarn);SYSLIB0001;SYSLIB0003;SYSLIB0011</NoWarn>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
@@ -34,7 +34,7 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <Compile Remove="Context\Attributes\FailAssemblyObjectDefinitionScannerTests.cs" />
     <Compile Remove="Context\Support\ApplicationContextAwareProcessorTests.cs" />
     <Compile Remove="Expressions\ExpressionEvaluatorTests.cs" />

--- a/test/Spring/Spring.Core.Tests/TestAssemblySetup.cs
+++ b/test/Spring/Spring.Core.Tests/TestAssemblySetup.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Threading;
-
 using NUnit.Framework;
 
 namespace Spring

--- a/test/Spring/Spring.Core.Tests/TestResourceLoader.cs
+++ b/test/Spring/Spring.Core.Tests/TestResourceLoader.cs
@@ -45,6 +45,7 @@ namespace Spring
             }
         }
 
+        #pragma warning disable SYSLIB0014 // WebRequest is obsolete
         public class TestResourceWebRequest : WebRequest
         {
             private Uri requestUri;
@@ -58,8 +59,8 @@ namespace Spring
             {
                 return new TestResourceWebResponse(requestUri);
             }
-
         }
+        #pragma warning restore SYSLIB0014 // WebRequest is obsolete
 
         public class TestResourceWebRequestFactory : IWebRequestCreate
         {

--- a/test/Spring/Spring.Data.Integration.Tests/Data/SQLiteTests.cs
+++ b/test/Spring/Spring.Data.Integration.Tests/Data/SQLiteTests.cs
@@ -1,7 +1,7 @@
 #region License
 
 /*
- * Copyright © 2002-2011 the original author or authors.
+ * Copyright ï¿½ 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
  */
 
 #endregion
-
-#if !MONO
 
 #region Imports
 
@@ -415,5 +413,3 @@ namespace Spring.Data
         }
     }
 }
-
-#endif

--- a/test/Spring/Spring.Data.Integration.Tests/Spring.Data.Integration.Tests.csproj
+++ b/test/Spring/Spring.Data.Integration.Tests/Spring.Data.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Aop\Spring.Aop.csproj" />
@@ -22,7 +22,7 @@
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <Compile Remove="Data\SQLiteTests.cs" />
     <Compile Remove="Data\OracleAdoTemplateTests.cs" />
   </ItemGroup>

--- a/test/Spring/Spring.Data.NHibernate5.Integration.Tests/Spring.Data.NHibernate5.Integration.Tests.csproj
+++ b/test/Spring/Spring.Data.NHibernate5.Integration.Tests/Spring.Data.NHibernate5.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Aop\Spring.Aop.csproj" />

--- a/test/Spring/Spring.Data.NHibernate5.NestedTxSuspension.Integration.Tests/Spring.Data.NHibernate5.NestedTxSuspension.Integration.Tests.csproj
+++ b/test/Spring/Spring.Data.NHibernate5.NestedTxSuspension.Integration.Tests/Spring.Data.NHibernate5.NestedTxSuspension.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <RootNamespace>Spring.Data.NHibernate5.NestedTxSuspension.Integration.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Spring/Spring.Data.NHibernate5.Tests/Spring.Data.NHibernate5.Tests.csproj
+++ b/test/Spring/Spring.Data.NHibernate5.Tests/Spring.Data.NHibernate5.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spring.Data.Tests\Spring.Data.Tests.csproj" />

--- a/test/Spring/Spring.Data.Tests/Spring.Data.Tests.csproj
+++ b/test/Spring/Spring.Data.Tests/Spring.Data.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
   </PropertyGroup>
   <ItemGroup>
@@ -23,7 +23,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitTestAdapterVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <Compile Remove="Data\Core\ServiceDomainTransactionManagerTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Spring/Spring.Messaging.Ems.Integration.Tests/Spring.Messaging.Ems.Integration.Tests.csproj
+++ b/test/Spring/Spring.Messaging.Ems.Integration.Tests/Spring.Messaging.Ems.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Aop\Spring.Aop.csproj" />

--- a/test/Spring/Spring.Messaging.Nms.Integration.Tests/Spring.Messaging.Nms.Integration.Tests.csproj
+++ b/test/Spring/Spring.Messaging.Nms.Integration.Tests/Spring.Messaging.Nms.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Messaging.Nms.Tests/Spring.Messaging.Nms.Tests.csproj
+++ b/test/Spring/Spring.Messaging.Nms.Tests/Spring.Messaging.Nms.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Messaging.Tests/Spring.Messaging.Tests.csproj
+++ b/test/Spring/Spring.Messaging.Tests/Spring.Messaging.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Scheduling.Quartz3.Integration.Tests/Spring.Scheduling.Quartz3.Integration.Tests.csproj
+++ b/test/Spring/Spring.Scheduling.Quartz3.Integration.Tests/Spring.Scheduling.Quartz3.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Scheduling.Quartz3.Tests/Scheduling/Quartz/QuartzSupportTests.cs
+++ b/test/Spring/Spring.Scheduling.Quartz3.Tests/Scheduling/Quartz/QuartzSupportTests.cs
@@ -601,7 +601,7 @@ namespace Spring.Scheduling.Quartz
             factoryObject.AfterPropertiesSet();
             await factoryObject.Start();
 
-            DummyRunnable.runEvent.WaitOne(1000);
+            DummyRunnable.runEvent.WaitOne(TimeSpan.FromSeconds(5));
             Assert.IsTrue(DummyRunnable.count > 0);
 
             factoryObject.Dispose();
@@ -634,7 +634,7 @@ namespace Spring.Scheduling.Quartz
             factoryObject.AfterPropertiesSet();
             await factoryObject.Start();
 
-            Thread.Sleep(500);
+            await Task.Delay(TimeSpan.FromSeconds(1));
             Assert.AreEqual(10, DummyJobObject.param);
             Assert.IsTrue(DummyJobObject.count > 0);
 
@@ -670,7 +670,7 @@ namespace Spring.Scheduling.Quartz
             factoryObject.AfterPropertiesSet();
             await factoryObject.Start();
 
-            Thread.Sleep(500);
+            await Task.Delay(TimeSpan.FromSeconds(1));
             Assert.AreEqual(10, DummyJob.param);
             Assert.IsTrue(DummyJob.count > 0);
 
@@ -680,7 +680,7 @@ namespace Spring.Scheduling.Quartz
         /// <summary>
         /// </summary>
         [Test]
-        public void TestSchedulerWithSpringObjectJobFactoryAndParamMismatchNotIgnored()
+        public async Task TestSchedulerWithSpringObjectJobFactoryAndParamMismatchNotIgnored()
         {
             DummyJob.param = 0;
             DummyJob.count = 0;
@@ -707,7 +707,7 @@ namespace Spring.Scheduling.Quartz
             bean.JobDetails = new IJobDetail[] {jobDetail};
             bean.AfterPropertiesSet();
 
-            Thread.Sleep(500);
+            await Task.Delay(TimeSpan.FromSeconds(1));
             Assert.AreEqual(0, DummyJob.param);
             Assert.IsTrue(DummyJob.count == 0);
 

--- a/test/Spring/Spring.Scheduling.Quartz3.Tests/Spring.Scheduling.Quartz3.Tests.csproj
+++ b/test/Spring/Spring.Scheduling.Quartz3.Tests/Spring.Scheduling.Quartz3.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Services.Tests/EnterpriseServices/ExportedServicedComponentSample.cs
+++ b/test/Spring/Spring.Services.Tests/EnterpriseServices/ExportedServicedComponentSample.cs
@@ -1,7 +1,7 @@
 #region License
 
 /*
- * Copyright © 2002-2011 the original author or authors.
+ * Copyright ï¿½ 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,11 @@
 
 #endregion
 
-#if !MONO
-
-#region Imports
-
 using System;
 using System.Diagnostics;
 using System.EnterpriseServices;
 using System.IO;
 using System.Reflection;
-
-#endregion
 
 /*
 The code below is only for reverse engineering generated code in reflector
@@ -75,4 +69,3 @@ namespace Spring.EnterpriseServices
         }
     }
 }
-#endif

--- a/test/Spring/Spring.Services.Tests/EnterpriseServices/ServicedComponentExporterTests.cs
+++ b/test/Spring/Spring.Services.Tests/EnterpriseServices/ServicedComponentExporterTests.cs
@@ -18,8 +18,6 @@
 
 #endregion
 
-#if !MONO
-
 #region Imports
 
 using System;
@@ -212,5 +210,3 @@ namespace Spring.EnterpriseServices
         #endregion
     }
 }
-
-#endif // !MONO

--- a/test/Spring/Spring.Services.Tests/Spring.Services.Tests.csproj
+++ b/test/Spring/Spring.Services.Tests/Spring.Services.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Aop\Spring.Aop.csproj" />

--- a/test/Spring/Spring.Template.Velocity.Castle.Tests/Spring.Template.Velocity.Castle.Tests.csproj
+++ b/test/Spring/Spring.Template.Velocity.Castle.Tests/Spring.Template.Velocity.Castle.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Template.Velocity.Tests/Spring.Template.Velocity.Tests.csproj
+++ b/test/Spring/Spring.Template.Velocity.Tests/Spring.Template.Velocity.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Testing.Microsoft.Tests/Spring.Testing.Microsoft.Tests.csproj
+++ b/test/Spring/Spring.Testing.Microsoft.Tests/Spring.Testing.Microsoft.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Testing.NUnit.Tests/Spring.Testing.NUnit.Tests.csproj
+++ b/test/Spring/Spring.Testing.NUnit.Tests/Spring.Testing.NUnit.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(TargetFullFrameworkVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Web.Conversation.NHibernate5.Tests/Spring.Web.Conversation.NHibernate5.Tests.csproj
+++ b/test/Spring/Spring.Web.Conversation.NHibernate5.Tests/Spring.Web.Conversation.NHibernate5.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
     <ContentSQLiteInteropFiles>true</ContentSQLiteInteropFiles>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>

--- a/test/Spring/Spring.Web.Mvc5.Tests/Spring.Web.Mvc5.Tests.csproj
+++ b/test/Spring/Spring.Web.Mvc5.Tests/Spring.Web.Mvc5.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />

--- a/test/Spring/Spring.Web.Tests/Spring.Web.Tests.csproj
+++ b/test/Spring/Spring.Web.Tests/Spring.Web.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(TargetFullFrameworkVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Spring\Spring.Core\Spring.Core.csproj" />


### PR DESCRIPTION
After a [change](https://github.com/spring-projects/spring-net/commit/05de414adc16956003b81c16e6ac1b75deaa7fe0) that replaced IDictionary with generic IDictionary<string, object> in EvaluationContext class, ReferenceNode throws KeyNotFoundException instead of using default context (non generic dictionaries return null when key does not exsist). I came across this bug when i was trying to resolve Spring expression like this: `expression.GetValue(arg.ExpressionContext, arg.ExpressionVariables)`, where `expression `is of type IExpression. This forced me to add a line like this: `arg.ExpressionVariables[Expression.ReservedVariableNames.RESERVEDPREFIX + "CurrentObjectFactory"] = ContextRegistry.GetContext();` in my code as a workaround.

I have added a check in ReferenceNode that verifies whether key is present in dictionary, and uses default context when it's not (as was initially intended I guess). I have also created some additional unit tests that cover cases I mentioned above.



