### PR TITLE
Restore compatibility with Quartz v3.12.0 and newer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="NVelocity" Version="1.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Quartz" Version="3.2.3" />
+    <PackageVersion Include="Quartz" Version="3.12.0" />
     <PackageVersion Include="System.CodeDom" Version="5.0.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />

--- a/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/QuartzJobObject.cs
+++ b/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/QuartzJobObject.cs
@@ -62,8 +62,8 @@ public abstract class QuartzJobObject : IJob
         {
             ObjectWrapper bw = new ObjectWrapper(this);
             MutablePropertyValues pvs = new MutablePropertyValues();
-            pvs.AddAll(context.Scheduler.Context);
-            pvs.AddAll(context.MergedJobDataMap);
+            pvs.AddAll((IDictionary<string, object>) context.Scheduler.Context);
+            pvs.AddAll((IDictionary<string, object>) context.MergedJobDataMap);
             bw.SetPropertyValues(pvs, true);
         }
         catch (SchedulerException ex)

--- a/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/SchedulerAccessorObject.cs
+++ b/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/SchedulerAccessorObject.cs
@@ -139,8 +139,7 @@ public class SchedulerAccessorObject : SchedulerAccessor, IObjectFactoryAware, I
             }
         }
 
-        IScheduler schedulerInRepo = SchedulerRepository.Instance.Lookup(schedulerName)
-            .ConfigureAwait(false).GetAwaiter().GetResult();
+        IScheduler schedulerInRepo = SchedulerRepository.Instance.Lookup(schedulerName);
         if (schedulerInRepo == null)
         {
             throw new InvalidOperationException("No Scheduler named '" + schedulerName + "' found");

--- a/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/SchedulerFactoryObject.cs
+++ b/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/SchedulerFactoryObject.cs
@@ -702,7 +702,7 @@ public class SchedulerFactoryObject : SchedulerAccessor, IFactoryObject, IObject
         lock (repository)
         {
             IScheduler existingScheduler = schedulerName != null
-                ? repository.Lookup(schedulerName).ConfigureAwait(false).GetAwaiter().GetResult()
+                ? repository.Lookup(schedulerName)
                 : null;
 
             IScheduler newScheduler =

--- a/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/SpringObjectJobFactory.cs
+++ b/src/Spring/Spring.Scheduling.Quartz3/Scheduling/Quartz/SpringObjectJobFactory.cs
@@ -76,11 +76,11 @@ public class SpringObjectJobFactory : AdaptableJobFactory, ISchedulerContextAwar
             MutablePropertyValues pvs = new MutablePropertyValues();
             if (schedulerContext != null)
             {
-                pvs.AddAll(schedulerContext);
+                pvs.AddAll((IDictionary<string, object>) schedulerContext);
             }
 
-            pvs.AddAll(bundle.JobDetail.JobDataMap);
-            pvs.AddAll(bundle.Trigger.JobDataMap);
+            pvs.AddAll((IDictionary<string, object>) bundle.JobDetail.JobDataMap);
+            pvs.AddAll((IDictionary<string, object>) bundle.Trigger.JobDataMap);
             if (ignoredUnknownProperties != null)
             {
                 for (int i = 0; i < ignoredUnknownProperties.Length; i++)

--- a/test/Spring/Spring.Scheduling.Quartz3.Tests/Scheduling/Quartz/QuartzSupportTests.cs
+++ b/test/Spring/Spring.Scheduling.Quartz3.Tests/Scheduling/Quartz/QuartzSupportTests.cs
@@ -923,9 +923,10 @@ public class QuartzSupportTests
     public async Task TestSchedulerRepositoryExposure()
     {
         XmlApplicationContext ctx = new XmlApplicationContext("schedulerRepositoryExposure.xml");
-        var expected = await SchedulerRepository.Instance.Lookup("myScheduler");
+        var expected = SchedulerRepository.Instance.Lookup("myScheduler");
         Assert.AreSame(expected, ctx.GetObject("scheduler"));
         ctx.Dispose();
+        await Task.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
- Due to API changes in Quartz v3.12.0, Spring.Scheduling.Quartz3 is not compatible with Quartz as of v3.12.0.