### PR TITLE
Fix 'occured' -> 'occurred' typos across Spring.Net (17 files)

### DIFF
--- a/src/Spring/Spring.Core/Context/ApplicationEventArgs.cs
+++ b/src/Spring/Spring.Core/Context/ApplicationEventArgs.cs
@@ -40,10 +40,10 @@ public class ApplicationEventArgs : EventArgs
     }
 
     /// <summary>
-    /// The date and time when the event occured.
+    /// The date and time when the event occurred.
     /// </summary>
     /// <value>
-    /// The date and time when the event occured.
+    /// The date and time when the event occurred.
     /// </value>
     public DateTime TimeStamp
     {

--- a/src/Spring/Spring.Core/Context/Support/AbstractApplicationContext.cs
+++ b/src/Spring/Spring.Core/Context/Support/AbstractApplicationContext.cs
@@ -390,7 +390,7 @@ public abstract class AbstractApplicationContext
         {
             Delegate target = ContextEvent.GetInvocationList()[0];
             Exception exception = exceptions[target];
-            throw new ApplicationContextException(string.Format("An unhandled exception occured during processing application event {0} in handler {1}", e.GetType(), target.Method), exception);
+            throw new ApplicationContextException(string.Format("An unhandled exception occurred during processing application event {0} in handler {1}", e.GetType(), target.Method), exception);
         }
     }
 

--- a/src/Spring/Spring.Core/Objects/Factory/Config/DelegateFactoryObject.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Config/DelegateFactoryObject.cs
@@ -79,7 +79,7 @@ public class DelegateFactoryObject : AbstractFactoryObject
     /// Creates the delegate.
     /// </summary>
     /// <exception cref="System.Exception">
-    /// If an exception occured during object creation.
+    /// If an exception occurred during object creation.
     /// </exception>
     /// <returns>The object returned by this factory.</returns>
     /// <seealso cref="Spring.Objects.Factory.Config.AbstractFactoryObject.CreateInstance()"/>

--- a/src/Spring/Spring.Core/Objects/Factory/Config/PropertyOverrideConfigurer.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Config/PropertyOverrideConfigurer.cs
@@ -111,7 +111,7 @@ public class PropertyOverrideConfigurer : PropertyResourceConfigurer
     /// </param>
     /// <param name="props">The properties to apply.</param>
     /// <exception cref="Spring.Objects.ObjectsException">
-    /// If an error occured.
+    /// If an error occurred.
     /// </exception>
     protected override void ProcessProperties(
         IConfigurableListableObjectFactory factory, NameValueCollection props)

--- a/src/Spring/Spring.Core/Objects/Factory/Config/PropertyPlaceholderConfigurer.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Config/PropertyPlaceholderConfigurer.cs
@@ -215,7 +215,7 @@ public class PropertyPlaceholderConfigurer : PropertyResourceConfigurer
     /// </param>
     /// <param name="props">The properties to apply.</param>
     /// <exception cref="Spring.Objects.ObjectsException">
-    /// If an error occured.
+    /// If an error occurred.
     /// </exception>
     protected override void ProcessProperties(IConfigurableListableObjectFactory factory, NameValueCollection props)
     {

--- a/src/Spring/Spring.Core/Objects/Factory/Config/PropertyRetrievingFactoryObject.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Config/PropertyRetrievingFactoryObject.cs
@@ -238,7 +238,7 @@ public class PropertyRetrievingFactoryObject : AbstractFactoryObject, IInitializ
     /// returned by this factory.
     /// </summary>
     /// <exception cref="System.Exception">
-    /// If an exception occured during object creation.
+    /// If an exception occurred during object creation.
     /// </exception>
     /// <returns>The object returned by this factory.</returns>
     protected override object CreateInstance()

--- a/src/Spring/Spring.Core/Objects/Factory/Config/VariablePlaceholderConfigurer.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Config/VariablePlaceholderConfigurer.cs
@@ -223,7 +223,7 @@ public class VariablePlaceholderConfigurer : IObjectFactoryPostProcessor, IPrior
     /// used by the application context.
     /// </param>
     /// <exception cref="Spring.Objects.ObjectsException">
-    /// If an error occured.
+    /// If an error occurred.
     /// </exception>
     protected virtual void ProcessProperties(IConfigurableListableObjectFactory factory)
     {

--- a/src/Spring/Spring.Core/Util/ConfigurationUtils.cs
+++ b/src/Spring/Spring.Core/Util/ConfigurationUtils.cs
@@ -101,7 +101,7 @@ public static class ConfigurationUtils
     /// <param name="message">The message to display to the client when the exception is thrown.</param>
     /// <param name="inner">The inner exception.</param>
     /// <param name="fileName">Name of the configuration file.</param>
-    /// <param name="line">The line where exception occured.</param>
+    /// <param name="line">The line where exception occurred.</param>
     /// <returns>Configuration exception.</returns>
     public static Exception CreateConfigurationException(string message, Exception inner, string fileName, int line)
     {
@@ -113,7 +113,7 @@ public static class ConfigurationUtils
     /// </summary>
     /// <param name="message">The message to display to the client when the exception is thrown.</param>
     /// <param name="fileName">Name of the configuration file.</param>
-    /// <param name="line">The line where exception occured.</param>
+    /// <param name="line">The line where exception occurred.</param>
     /// <returns>Configuration exception.</returns>
     public static Exception CreateConfigurationException(string message, string fileName, int line)
     {
@@ -125,7 +125,7 @@ public static class ConfigurationUtils
     /// </summary>
     /// <param name="message">The message to display to the client when the exception is thrown.</param>
     /// <param name="inner">The inner exception.</param>
-    /// <param name="node">XML node where exception occured.</param>
+    /// <param name="node">XML node where exception occurred.</param>
     /// <returns>Configuration exception.</returns>
     public static Exception CreateConfigurationException(string message, Exception inner, XmlNode node)
     {
@@ -136,7 +136,7 @@ public static class ConfigurationUtils
     /// Creates the configuration exception.
     /// </summary>
     /// <param name="message">The message to display to the client when the exception is thrown.</param>
-    /// <param name="node">XML node where exception occured.</param>
+    /// <param name="node">XML node where exception occurred.</param>
     /// <returns>Configuration exception.</returns>
     public static Exception CreateConfigurationException(string message, XmlNode node)
     {

--- a/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/Generic/HibernateDaoSupport.cs
+++ b/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/Generic/HibernateDaoSupport.cs
@@ -179,7 +179,7 @@ public abstract class HibernateDaoSupport : DaoSupport
     /// <code>org.springframework.dao</code> hierarchy. Will automatically detect
     /// wrapped ADO.NET Exceptions and convert them accordingly.
     /// </summary>
-    /// <param name="ex">HibernateException that occured.</param>
+    /// <param name="ex">HibernateException that occurred.</param>
     /// <returns>
     /// The corresponding DataAccessException instance
     /// </returns>

--- a/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/HibernateAccessor.cs
+++ b/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/HibernateAccessor.cs
@@ -391,7 +391,7 @@ public abstract class HibernateAccessor : IInitializingObject, IObjectFactoryAwa
     /// <code>org.springframework.dao</code> hierarchy. Will automatically detect
     /// wrapped ADO.NET Exceptions and convert them accordingly.
     /// </summary>
-    /// <param name="ex">HibernateException that occured.</param>
+    /// <param name="ex">HibernateException that occurred.</param>
     /// <returns>
     /// The corresponding DataAccessException instance
     /// </returns>
@@ -413,7 +413,7 @@ public abstract class HibernateAccessor : IInitializingObject, IObjectFactoryAwa
     /// Converts the ADO.NET access exception to an appropriate exception from the
     /// <code>org.springframework.dao</code> hierarchy. Can be overridden in subclasses.
     /// </summary>
-    /// <param name="ex">ADOException that occured, wrapping underlying ADO.NET exception.</param>
+    /// <param name="ex">ADOException that occurred, wrapping underlying ADO.NET exception.</param>
     /// <returns>
     /// the corresponding DataAccessException instance
     /// </returns>

--- a/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/HibernateTransactionManager.cs
+++ b/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/HibernateTransactionManager.cs
@@ -658,7 +658,7 @@ public class HibernateTransactionManager : AbstractPlatformTransactionManager, I
     /// Convert the given HibernateException to an appropriate exception from
     /// the Spring.Dao hierarchy. Can be overridden in subclasses.
     /// </summary>
-    /// <param name="ex">The HibernateException that occured.</param>
+    /// <param name="ex">The HibernateException that occurred.</param>
     /// <returns>The corresponding DataAccessException instance</returns>
     protected virtual DataAccessException ConvertHibernateAccessException(HibernateException ex)
     {
@@ -678,7 +678,7 @@ public class HibernateTransactionManager : AbstractPlatformTransactionManager, I
     /// Convert the given ADOException to an appropriate exception from the
     /// the Spring.Dao hierarchy. Can be overridden in subclasses.
     /// </summary>
-    /// <param name="ex">The ADOException that occured, wrapping the underlying
+    /// <param name="ex">The ADOException that occurred, wrapping the underlying
     /// ADO.NET thrown exception.</param>
     /// <param name="translator">The translator to convert hibernate ADOExceptions.</param>
     /// <returns>

--- a/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/HibernateTxScopeTransactionManager.cs
+++ b/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/HibernateTxScopeTransactionManager.cs
@@ -846,7 +846,7 @@ public class HibernateTxScopeTransactionManager : AbstractPlatformTransactionMan
     /// Convert the given HibernateException to an appropriate exception from
     /// the Spring.Dao hierarchy. Can be overridden in subclasses.
     /// </summary>
-    /// <param name="ex">The HibernateException that occured.</param>
+    /// <param name="ex">The HibernateException that occurred.</param>
     /// <returns>The corresponding DataAccessException instance</returns>
     protected virtual DataAccessException ConvertHibernateAccessException(HibernateException ex)
     {
@@ -866,7 +866,7 @@ public class HibernateTxScopeTransactionManager : AbstractPlatformTransactionMan
     /// Convert the given ADOException to an appropriate exception from the
     /// the Spring.Dao hierarchy. Can be overridden in subclasses.
     /// </summary>
-    /// <param name="ex">The ADOException that occured, wrapping the underlying
+    /// <param name="ex">The ADOException that occurred, wrapping the underlying
     /// ADO.NET thrown exception.</param>
     /// <param name="translator">The translator to convert hibernate ADOExceptions.</param>
     /// <returns>

--- a/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/LocalSessionFactoryObject.cs
+++ b/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/LocalSessionFactoryObject.cs
@@ -965,7 +965,7 @@ public class LocalSessionFactoryObject : IFactoryObject, IInitializingObject, IP
     /// Will automatically apply a specified IAdoExceptionTranslator to a
     /// Hibernate ADOException, else rely on Hibernate's default translation.
     /// </summary>
-    /// <param name="ex">The Hibernate exception that occured.</param>
+    /// <param name="ex">The Hibernate exception that occurred.</param>
     /// <returns>A corresponding DataAccessException</returns>
     protected virtual DataAccessException ConvertHibernateException(HibernateException ex)
     {
@@ -981,7 +981,7 @@ public class LocalSessionFactoryObject : IFactoryObject, IInitializingObject, IP
     /// Converts the ADO.NET access exception to an appropriate exception from the
     /// <code>org.springframework.dao</code> hierarchy. Can be overridden in subclasses.
     /// </summary>
-    /// <param name="ex">ADOException that occured, wrapping underlying ADO.NET exception.</param>
+    /// <param name="ex">ADOException that occurred, wrapping underlying ADO.NET exception.</param>
     /// <returns>
     /// the corresponding DataAccessException instance
     /// </returns>

--- a/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/SessionFactoryUtils.cs
+++ b/src/Spring/Spring.Data.NHibernate5/Data/NHibernate/SessionFactoryUtils.cs
@@ -411,7 +411,7 @@ public abstract class SessionFactoryUtils
     /// handle AdoException specifically by using a AdoExceptionTranslator for the
     /// underlying ADO.NET exception.
     /// </summary>
-    /// <param name="ex">The Hibernate exception that occured.</param>
+    /// <param name="ex">The Hibernate exception that occurred.</param>
     /// <returns>DataAccessException instance</returns>
     public static DataAccessException ConvertHibernateAccessException(HibernateException ex)
     {

--- a/src/Spring/Spring.Services/Remoting/CaoFactoryObject.cs
+++ b/src/Spring/Spring.Services/Remoting/CaoFactoryObject.cs
@@ -72,7 +72,7 @@ public class CaoFactoryObject : IFactoryObject, IInitializingObject
     /// <summary>
     /// Callback method called once all factory properties have been set.
     /// </summary>
-    /// <exception cref="System.Exception">if an error occured</exception>
+    /// <exception cref="System.Exception">if an error occurred</exception>
     public void AfterPropertiesSet()
     {
         if (RemoteTargetName == null)

--- a/src/Spring/Spring.Services/Remoting/SaoFactoryObject.cs
+++ b/src/Spring/Spring.Services/Remoting/SaoFactoryObject.cs
@@ -64,7 +64,7 @@ public class SaoFactoryObject : IFactoryObject, IInitializingObject
     /// <summary>
     /// Callback method called once all factory properties have been set.
     /// </summary>
-    /// <exception cref="System.Exception">if an error occured</exception>
+    /// <exception cref="System.Exception">if an error occurred</exception>
     public void AfterPropertiesSet()
     {
         if (ServiceUrl == null)

--- a/src/Spring/Spring.Web/Web/Support/Result.cs
+++ b/src/Spring/Spring.Web/Web/Support/Result.cs
@@ -374,7 +374,7 @@ public class Result : IResult
     /// </summary>
     /// <param name="context">the context to be used for evaluation.</param>
     /// <param name="value">the string that might need evaluation</param>
-    /// <returns>the evaluation result. Unodified <paramref name="value"/> if no evalution occured.</returns>
+    /// <returns>the evaluation result. Unodified <paramref name="value"/> if no evalution occurred.</returns>
     protected virtual object ResolveValueIfNecessary(object context, string value)
     {
         return ResolveSpELRuntimeExpressionIfNecessary(context, value);


### PR DESCRIPTION
Fix 25 instances of `occured` → `occurred` across 17 C# files in Spring.Net. All are XML doc comments, exception messages, or inline comments. No code or behavior change.

## Files by instance count

| File | Instances |
|------|-----------|
| `Spring.Core/Util/ConfigurationUtils.cs` | 4 |
| `Spring.Core/Context/ApplicationEventArgs.cs` | 2 |
| `Spring.Data.NHibernate5/Data/NHibernate/LocalSessionFactoryObject.cs` | 2 |
| `Spring.Data.NHibernate5/Data/NHibernate/HibernateTxScopeTransactionManager.cs` | 2 |
| `Spring.Data.NHibernate5/Data/NHibernate/HibernateAccessor.cs` | 2 |
| `Spring.Data.NHibernate5/Data/NHibernate/HibernateTransactionManager.cs` | 2 |
| 11 other files | 1 each |

## Testing

XML-doc/comment/exception-message change only. No tests impacted.