### PR TITLE
Fix SimpleLoggingAdvice configuration breakage from the MS logging migration

### DIFF
--- a/src/Spring/Spring.Aop/Aspects/Logging/AbstractLoggingAdvice.cs
+++ b/src/Spring/Spring.Aop/Aspects/Logging/AbstractLoggingAdvice.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using System.Reflection;
 using System.Runtime.Serialization;
 using AopAlliance.Intercept;
 using Microsoft.Extensions.Logging;
@@ -33,7 +32,9 @@ namespace Spring.Aspects.Logging;
 public abstract class AbstractLoggingAdvice : IMethodInterceptor, IDeserializationCallback
 {
     /// <summary>
-    /// The default <code>ILog</code> instance used to write logging messages.
+    /// The explicitly supplied <see cref="ILogger"/> instance used to write logging messages,
+    /// if any. When <c>null</c>, the logger is resolved through <see cref="LogManager"/>,
+    /// either by <see cref="defaultLoggerName"/> or dynamically per invocation.
     /// </summary>
     [NonSerialized] protected ILogger defaultLogger;
 
@@ -52,7 +53,7 @@ public abstract class AbstractLoggingAdvice : IMethodInterceptor, IDeserializati
     /// </summary>
     protected AbstractLoggingAdvice()
     {
-        SetDefaultLogger(MethodBase.GetCurrentMethod().DeclaringType.FullName);
+        SetDefaultLogger(GetType().FullName);
     }
 
     /// <summary>
@@ -89,8 +90,9 @@ public abstract class AbstractLoggingAdvice : IMethodInterceptor, IDeserializati
     /// Sets the name of the logger to use.
     /// </summary>
     /// <remarks>
-    /// The name will be passed to the underlying logging implementation through Common.Logging,
-    /// getting interpreted as the log category according to the loggers configuration.
+    /// The name will be passed to the underlying logging implementation through the configured
+    /// <see cref="LogManager.LoggerFactory"/>, getting interpreted as the log category
+    /// according to the loggers configuration.
     /// <para>
     /// This can be specified to not log into the category of a Type (whether this
     /// interceptor's class or the class getting called) but rather to a specific named category.
@@ -227,26 +229,35 @@ public abstract class AbstractLoggingAdvice : IMethodInterceptor, IDeserializati
         {
             return defaultLogger;
         }
-        else
-        {
-            object target = invocation.This;
-            Type logCategoryType = target.GetType();
-            if (hideProxyTypeNames)
-            {
-                logCategoryType = AopUtils.GetTargetType(target);
-            }
 
-            return LogManager.GetLogger(logCategoryType);
+        if (defaultLoggerName != null)
+        {
+            return LogManager.GetLogger(defaultLoggerName);
         }
+
+        object target = invocation.This;
+        Type logCategoryType = target.GetType();
+        if (hideProxyTypeNames)
+        {
+            logCategoryType = AopUtils.GetTargetType(target);
+        }
+
+        return LogManager.GetLogger(logCategoryType);
     }
 
     /// <summary>
-    /// Sets the default logger to the given name.
+    /// Sets the name of the default logger.
     /// </summary>
-    /// <param name="name">if <c>null</c>, the default logger is removed.</param>
+    /// <remarks>
+    /// The logger is resolved lazily through <see cref="LogManager"/> on each invocation,
+    /// so a <see cref="LogManager.LoggerFactory"/> assigned after this advice has been
+    /// created is still picked up.
+    /// </remarks>
+    /// <param name="name">if <c>null</c>, the default logger is removed and a dynamic,
+    /// per-target logger is used instead.</param>
     protected void SetDefaultLogger(string name)
     {
-        defaultLogger = (name == null ? null : LogManager.GetLogger(name));
+        defaultLogger = null;
         defaultLoggerName = name;
     }
 

--- a/src/Spring/Spring.Aop/Aspects/Logging/SimpleLoggingAdvice.cs
+++ b/src/Spring/Spring.Aop/Aspects/Logging/SimpleLoggingAdvice.cs
@@ -140,6 +140,12 @@ public class SimpleLoggingAdvice : AbstractLoggingAdvice
     /// <summary>
     /// Gets or sets the entry log level.
     /// </summary>
+    /// <remarks>
+    /// When configured from a string value, the legacy Common.Logging level names used by
+    /// Spring.NET configurations prior to 3.0 are also accepted: <c>All</c> maps to
+    /// <c>Trace</c>, <c>Info</c> to <c>Information</c>, <c>Warn</c> to <c>Warning</c>,
+    /// <c>Fatal</c> to <c>Critical</c> and <c>Off</c> to <c>None</c>.
+    /// </remarks>
     /// <value>The entry log level.</value>
     public LogLevel LogLevel
     {

--- a/src/Spring/Spring.Core/Core/TypeConversion/LogLevelConverter.cs
+++ b/src/Spring/Spring.Core/Core/TypeConversion/LogLevelConverter.cs
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace Spring.Core.TypeConversion;
+
+/// <summary>
+/// Converter for <see cref="Microsoft.Extensions.Logging.LogLevel"/> instances.
+/// </summary>
+/// <remarks>
+/// In addition to the <see cref="Microsoft.Extensions.Logging.LogLevel"/> member names
+/// (<c>Trace</c>, <c>Debug</c>, <c>Information</c>, <c>Warning</c>, <c>Error</c>,
+/// <c>Critical</c>, <c>None</c>), the legacy Common.Logging level names used by
+/// Spring.NET configurations prior to 3.0 are accepted: <c>All</c> maps to
+/// <c>Trace</c>, <c>Info</c> to <c>Information</c>, <c>Warn</c> to <c>Warning</c>,
+/// <c>Fatal</c> to <c>Critical</c> and <c>Off</c> to <c>None</c>.
+/// Names are matched case-insensitively.
+/// </remarks>
+public class LogLevelConverter : EnumConverter
+{
+    private static readonly Dictionary<string, LogLevel> LegacyLevels = new Dictionary<string, LogLevel>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["All"] = LogLevel.Trace,
+        ["Info"] = LogLevel.Information,
+        ["Warn"] = LogLevel.Warning,
+        ["Fatal"] = LogLevel.Critical,
+        ["Off"] = LogLevel.None
+    };
+
+    /// <summary>
+    /// Creates a new instance of the
+    /// <see cref="Spring.Core.TypeConversion.LogLevelConverter"/> class.
+    /// </summary>
+    public LogLevelConverter() : base(typeof(LogLevel))
+    {
+    }
+
+    /// <summary>
+    /// Convert from a string value to a <see cref="Microsoft.Extensions.Logging.LogLevel"/> instance.
+    /// </summary>
+    /// <param name="context">
+    /// A <see cref="System.ComponentModel.ITypeDescriptorContext"/>
+    /// that provides a format context.
+    /// </param>
+    /// <param name="culture">
+    /// The <see cref="System.Globalization.CultureInfo"/> to use
+    /// as the current culture.
+    /// </param>
+    /// <param name="value">
+    /// The value that is to be converted.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Microsoft.Extensions.Logging.LogLevel"/> if successful.
+    /// </returns>
+    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+    {
+        if (value is string text && LegacyLevels.TryGetValue(text.Trim(), out LogLevel level))
+        {
+            return level;
+        }
+
+        return base.ConvertFrom(context, culture, value);
+    }
+}

--- a/src/Spring/Spring.Core/Core/TypeConversion/TypeConverterRegistry.cs
+++ b/src/Spring/Spring.Core/Core/TypeConversion/TypeConverterRegistry.cs
@@ -20,6 +20,7 @@ using System.Drawing;
 using System.Net;
 using System.Resources;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using Spring.Core.TypeResolution;
 using Spring.Util;
@@ -57,6 +58,7 @@ public class TypeConverterRegistry
             converters[typeof(ResourceManager)] = new ResourceManagerConverter();
             converters[typeof(Regex)] = new RegexConverter();
             converters[typeof(TimeSpan)] = new TimeSpanConverter();
+            converters[typeof(LogLevel)] = new LogLevelConverter();
             converters[typeof(ICredentials)] = new CredentialConverter();
             converters[typeof(NetworkCredential)] = new CredentialConverter();
             converters[typeof(RegistryKey)] = new RegistryKeyConverter();

--- a/src/Spring/Spring.Core/LogManager.cs
+++ b/src/Spring/Spring.Core/LogManager.cs
@@ -24,6 +24,12 @@ public static class LogManager
     /// <summary>
     /// Gets or sets the current log provider based on logger factory.
     /// </summary>
+    /// <remarks>
+    /// Until a factory is assigned, all loggers returned by the <c>GetLogger</c> methods
+    /// are no-op <see cref="NullLogger"/> instances. Assigning a factory takes effect for
+    /// all loggers resolved afterwards, including lazily resolved ones such as those used
+    /// by <c>Spring.Aspects.Logging.AbstractLoggingAdvice</c>.
+    /// </remarks>
     public static ILoggerFactory LoggerFactory { get; set; }
 
     public static ILogger GetLogger(string category) => LoggerFactory?.CreateLogger(category) ?? NullLogger.Instance;

--- a/test/Spring/Spring.Aop.Tests/Aspects/Logging/SimpleLoggingAdviceTests.cs
+++ b/test/Spring/Spring.Aop.Tests/Aspects/Logging/SimpleLoggingAdviceTests.cs
@@ -15,12 +15,15 @@
  */
 
 using System.Reflection;
+using System.Text;
 using AopAlliance.Intercept;
 using FakeItEasy;
 using FakeItEasy.Configuration;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Spring.Aop.Framework;
+using Spring.Core.IO;
+using Spring.Objects.Factory.Xml;
 
 namespace Spring.Aspects.Logging;
 
@@ -43,9 +46,18 @@ public class SimpleLoggingAdviceTests
         }
     }
 
+    private ILoggerFactory originalLoggerFactory;
+
     [SetUp]
     public void Setup()
     {
+        originalLoggerFactory = LogManager.LoggerFactory;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        LogManager.LoggerFactory = originalLoggerFactory;
     }
 
     [Test]
@@ -163,6 +175,93 @@ public class SimpleLoggingAdviceTests
 
         log.VerifyLogMustHaveHappened(LogLevel.Trace, "Entering Bark");
         log.VerifyLogMustHaveHappened(LogLevel.Trace, "Exiting Bark");
+    }
+
+    [Test]
+    public void LoggerFactoryAssignedAfterAdviceConstructionIsUsed()
+    {
+        LogManager.LoggerFactory = null;
+        SimpleLoggingAdvice loggingAdvice = new SimpleLoggingAdvice();
+
+        ProxyFactory pf = new ProxyFactory(new TestTarget());
+        pf.AddAdvice(loggingAdvice);
+        ITestTarget ptt = (ITestTarget) pf.GetProxy();
+
+        RecordingLoggerFactory loggerFactory = new RecordingLoggerFactory();
+        LogManager.LoggerFactory = loggerFactory;
+
+        ptt.DoSomething();
+
+        Assert.That(loggerFactory.Messages, Has.Some.Contains("Entering DoSomething"));
+        Assert.That(loggerFactory.Messages, Has.Some.Contains("Exiting DoSomething"));
+    }
+
+    [Test]
+    public void DefaultLoggerCategoryIsConcreteAdviceType()
+    {
+        RecordingLoggerFactory loggerFactory = new RecordingLoggerFactory();
+        LogManager.LoggerFactory = loggerFactory;
+
+        SimpleLoggingAdvice loggingAdvice = new SimpleLoggingAdvice();
+        ProxyFactory pf = new ProxyFactory(new TestTarget());
+        pf.AddAdvice(loggingAdvice);
+        ((ITestTarget) pf.GetProxy()).DoSomething();
+
+        Assert.That(loggerFactory.Categories, Does.Contain(typeof(SimpleLoggingAdvice).FullName));
+    }
+
+    [Test]
+    public void LegacyLogLevelNameCanBeConfiguredFromXml()
+    {
+        string xml = $@"<?xml version='1.0' encoding='UTF-8' ?>
+<objects xmlns='http://www.springframework.net'>
+    <object id='loggingAdvice' type='{typeof(SimpleLoggingAdvice).AssemblyQualifiedName}'>
+        <property name='LogLevel' value='Info'/>
+    </object>
+</objects>";
+
+        XmlObjectFactory objectFactory = new XmlObjectFactory(new StringResource(xml, Encoding.UTF8));
+        SimpleLoggingAdvice advice = (SimpleLoggingAdvice) objectFactory.GetObject("loggingAdvice");
+
+        Assert.That(advice.LogLevel, Is.EqualTo(LogLevel.Information));
+    }
+
+    private sealed class RecordingLoggerFactory : ILoggerFactory
+    {
+        public List<string> Categories { get; } = [];
+        public List<string> Messages { get; } = [];
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            Categories.Add(categoryName);
+            return new RecordingLogger(Messages);
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class RecordingLogger(List<string> messages) : ILogger
+        {
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                messages.Add(formatter(state, exception));
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+        }
     }
 }
 

--- a/test/Spring/Spring.Core.Tests/Core/TypeConversion/LogLevelConverterTests.cs
+++ b/test/Spring/Spring.Core.Tests/Core/TypeConversion/LogLevelConverterTests.cs
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+namespace Spring.Core.TypeConversion;
+
+/// <summary>
+/// Unit tests for the LogLevelConverter class.
+/// </summary>
+[TestFixture]
+public sealed class LogLevelConverterTests
+{
+    private readonly LogLevelConverter converter = new LogLevelConverter();
+
+    [TestCase("All", LogLevel.Trace)]
+    [TestCase("Info", LogLevel.Information)]
+    [TestCase("info", LogLevel.Information)]
+    [TestCase(" Info ", LogLevel.Information)]
+    [TestCase("Warn", LogLevel.Warning)]
+    [TestCase("WARN", LogLevel.Warning)]
+    [TestCase("Fatal", LogLevel.Critical)]
+    [TestCase("Off", LogLevel.None)]
+    public void ConvertsLegacyCommonLoggingLevelNames(string text, LogLevel expected)
+    {
+        Assert.That(converter.ConvertFrom(text), Is.EqualTo(expected));
+    }
+
+    [TestCase("Trace", LogLevel.Trace)]
+    [TestCase("Debug", LogLevel.Debug)]
+    [TestCase("Information", LogLevel.Information)]
+    [TestCase("information", LogLevel.Information)]
+    [TestCase("Warning", LogLevel.Warning)]
+    [TestCase("Error", LogLevel.Error)]
+    [TestCase("Critical", LogLevel.Critical)]
+    [TestCase("None", LogLevel.None)]
+    public void ConvertsCanonicalLevelNames(string text, LogLevel expected)
+    {
+        Assert.That(converter.ConvertFrom(text), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ConvertsNumericStrings()
+    {
+        Assert.That(converter.ConvertFrom("2"), Is.EqualTo(LogLevel.Information));
+    }
+
+    [Test]
+    public void ThrowsFormatExceptionForUnknownLevelName()
+    {
+        Assert.Throws<FormatException>(() => converter.ConvertFrom("Verbose"));
+    }
+
+    [Test]
+    public void CanConvertFromString()
+    {
+        Assert.IsTrue(converter.CanConvertFrom(typeof(string)));
+    }
+}

--- a/test/Spring/Spring.Core.Tests/Core/TypeConversion/TypeConversionUtilsTests.cs
+++ b/test/Spring/Spring.Core.Tests/Core/TypeConversion/TypeConversionUtilsTests.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 namespace Spring.Core.TypeConversion;
@@ -63,5 +64,18 @@ public class TypeConversionUtilsTests
     {
         object o = TypeConversionUtils.ConvertValueIfNecessary(typeof(Double), "1,2", "foo");
         Assert.That(o, Is.EqualTo(1.2));
+    }
+
+    [Test]
+    public void ConvertsLegacyCommonLoggingLogLevelName()
+    {
+        object o = TypeConversionUtils.ConvertValueIfNecessary(typeof(LogLevel), "Info", "LogLevel");
+        Assert.That(o, Is.EqualTo(LogLevel.Information));
+    }
+
+    [Test]
+    public void ThrowsTypeMismatchForUnknownLogLevelName()
+    {
+        Assert.Throws<TypeMismatchException>(() => TypeConversionUtils.ConvertValueIfNecessary(typeof(LogLevel), "Verbose", "LogLevel"));
     }
 }

--- a/test/Spring/Spring.Core.Tests/Core/TypeConversion/TypeConverterRegistryTests.cs
+++ b/test/Spring/Spring.Core.Tests/Core/TypeConversion/TypeConverterRegistryTests.cs
@@ -34,6 +34,13 @@ public sealed class TypeConverterRegistryTests
     }
 
     [Test]
+    public void GetConverterForLogLevel()
+    {
+        TypeConverter converter = TypeConverterRegistry.GetConverter(typeof(Microsoft.Extensions.Logging.LogLevel));
+        Assert.IsTrue(converter is LogLevelConverter);
+    }
+
+    [Test]
     public void GetInternalConverter()
     {
         TypeConverter converter = TypeConverterRegistry.GetConverter(typeof(int));


### PR DESCRIPTION
Fixes #341.

The Common.Logging → Microsoft.Extensions.Logging migration (fda46d95, #267) broke `SimpleLoggingAdvice` in two ways for anyone upgrading from ≤3.0.2:

1. **Legacy level names rejected.** `<property name="LogLevel" value="Info"/>` throws `TypeMismatchException`, because MEL's `LogLevel` has `Information`/`Warning`/`Critical`/`None` where Common.Logging had `Info`/`Warn`/`Fatal`/`Off`/`All`. The reference docs and example configs still use the old spellings.
2. **Silent advice.** `AbstractLoggingAdvice` resolved its static logger eagerly in the constructor. With `LogManager.LoggerFactory` typically still unset while the container builds the advice, that cached `NullLogger.Instance` forever — assigning the factory afterwards had no effect. The default log category was also always `AbstractLoggingAdvice` (a `MethodBase.GetCurrentMethod().DeclaringType` accident), never the concrete advice type, so category-based filter rules didn't match.

## Changes

- **New `LogLevelConverter`** (Spring.Core, registered in `TypeConverterRegistry`): accepts the legacy Common.Logging names case-insensitively — `All`→`Trace`, `Info`→`Information`, `Warn`→`Warning`, `Fatal`→`Critical`, `Off`→`None` — and delegates everything else to `EnumConverter`. Pre-3.0 XML configs (and the shipped reference docs/examples using `value="Info"`) work again. `LogExceptionHandler.LogLevel` gains the same support for free.
- **Lazy logger resolution** in `AbstractLoggingAdvice`: `SetDefaultLogger` now only stores the category name; the logger is resolved through `LogManager` per invocation (MEL's `LoggerFactory` caches loggers by category, so this matches the cost profile dynamic mode always had). A `LogManager.LoggerFactory` assigned any time before the first intercepted call now takes effect. This also keeps a deserialized static-mode advice in static mode (`defaultLogger` is `[NonSerialized]`; the name survives).
- **Default category** is now the concrete advice type (e.g. `Spring.Aspects.Logging.SimpleLoggingAdvice`), consistent with what the `UseDynamicLogger = false` setter path already did and with Java Spring's `getClass()` behavior.

## Behavior changes to be aware of

- The static-mode default category changes from `Spring.Aspects.Logging.AbstractLoggingAdvice` (accidental) to the concrete advice type's full name. Filter rules keyed on the old name need adjusting.
- The protected `defaultLogger` field now strictly means "explicitly supplied logger"; in named-logger mode it stays `null` and resolution goes through `LogManager` per invocation.

## Note for the issue reporter

The other half of #341 — no output even with `Information` — is expected in 3.x until `Spring.LogManager.LoggerFactory` is assigned (Common.Logging's app.config auto-configuration is gone). E.g. for log4net: `LogManager.LoggerFactory = LoggerFactory.Create(b => b.AddLog4Net());`. With this PR a factory assigned even after the context is built is picked up.

## Follow-up (not in this PR)

`LogExceptionHandler` builds a SpEL expression `#log.Information(...)` etc. — those instance methods don't exist on MEL `ILogger` (they're `LogXxx` extension methods), so its log action silently fails; needs a separate fix.

## Verification

- New unit tests: converter (legacy/canonical/case-insensitive/numeric/invalid names), registry lookup, `TypeConversionUtils` end-to-end, late `LoggerFactory` wiring, default category, and an `XmlObjectFactory` repro of the exact config from the issue.
- `dotnet build Spring.Net.sln` clean; full Spring.Aop.Tests and Spring.Core.Tests suites green on net8.0 and net462 (only known-local-env failure `FormatUsingDefaults` unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)