### PR TITLE
Fix per-request memory leak from inner object disposal tracking

### DIFF
--- a/src/Spring/Spring.Core/Objects/Factory/Support/AbstractAutowireCapableObjectFactory.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Support/AbstractAutowireCapableObjectFactory.cs
@@ -1721,6 +1721,13 @@ public abstract class AbstractAutowireCapableObjectFactory : AbstractObjectFacto
         RootObjectDefinition definition = GetMergedObjectDefinition(name, true);
         if (definition != null)
         {
+            // The target instance is externally managed and this method may be called for any
+            // number of instances of the same definition (e.g. once per web request), so it
+            // must not apply container-singleton semantics: otherwise every IDisposable inner
+            // object resolved during configuration would be registered for disposal on factory
+            // shutdown and be kept alive for the lifetime of the factory (GH-239).
+            definition = CreateRootObjectDefinition(definition);
+            definition.IsSingleton = false;
             return ConfigureObject(name, definition, new ObjectWrapper(target));
         }
 

--- a/src/Spring/Spring.Core/Objects/Factory/Support/AbstractObjectFactory.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Support/AbstractObjectFactory.cs
@@ -1661,6 +1661,27 @@ public abstract class AbstractObjectFactory : IConfigurableObjectFactory
     protected internal ISet DisposableInnerObjects => disposableInnerObjects;
 
     /// <summary>
+    /// Registers an <see cref="System.IDisposable"/> instance that was created from an inner
+    /// object definition of the object identified by <paramref name="ownerName"/>, so that it
+    /// is destroyed when this factory is disposed.
+    /// </summary>
+    /// <remarks>
+    /// Registration keeps a strong reference to <paramref name="instance"/> until the factory
+    /// is disposed. Subclasses may override this method to suppress registration for owner
+    /// scopes whose instances are created repeatedly (for example per-request web scopes),
+    /// where tracking every created inner instance until factory shutdown would grow without
+    /// bound (GH-239).
+    /// </remarks>
+    /// <param name="ownerName">
+    /// The name of the object whose definition contains the inner object definition.
+    /// </param>
+    /// <param name="instance">The inner object instance that requires disposal.</param>
+    protected internal virtual void RegisterDisposableInnerObject(string ownerName, object instance)
+    {
+        DisposableInnerObjects.Add(instance);
+    }
+
+    /// <summary>
     /// The parent object factory, or <see langword="null"/> if there is none.
     /// </summary>
     /// <value>

--- a/src/Spring/Spring.Core/Objects/Factory/Support/ObjectDefinitionValueResolver.cs
+++ b/src/Spring/Spring.Core/Objects/Factory/Support/ObjectDefinitionValueResolver.cs
@@ -304,7 +304,7 @@ public class ObjectDefinitionValueResolver
         {
             // keep a reference to the inner object instance, to be able to destroy
             // it on factory shutdown...
-            objectFactory.DisposableInnerObjects.Add(instance);
+            objectFactory.RegisterDisposableInnerObject(name, instance);
         }
 
         return result;

--- a/src/Spring/Spring.Web/Objects/Factory/Support/WebObjectFactory.cs
+++ b/src/Spring/Spring.Web/Objects/Factory/Support/WebObjectFactory.cs
@@ -351,6 +351,25 @@ public class WebObjectFactory : DefaultListableObjectFactory
     }
 
     /// <summary>
+    /// Suppresses factory-lifetime disposal tracking of inner objects created for
+    /// 'request'- and 'session'-scoped owners: such owners are instantiated anew for every
+    /// request/session, so keeping a reference to each created inner instance until factory
+    /// shutdown would grow without bound (GH-239).
+    /// </summary>
+    /// <param name="ownerName">
+    /// The name of the object whose definition contains the inner object definition.
+    /// </param>
+    /// <param name="instance">The inner object instance that requires disposal.</param>
+    protected override void RegisterDisposableInnerObject(string ownerName, object instance)
+    {
+        RootObjectDefinition ownerDefinition = GetMergedObjectDefinition(ownerName, true);
+        if (ownerDefinition == null || !IsWebScopedSingleton(ownerDefinition))
+        {
+            base.RegisterDisposableInnerObject(ownerName, instance);
+        }
+    }
+
+    /// <summary>
     /// Add the created, but yet unpopulated singleton to the singleton cache
     /// to be able to resolve circular references
     /// </summary>

--- a/test/Spring/Spring.Core.Tests/Objects/Factory/Support/DisposableInnerObjectTrackingTests.cs
+++ b/test/Spring/Spring.Core.Tests/Objects/Factory/Support/DisposableInnerObjectTrackingTests.cs
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using NUnit.Framework;
+
+namespace Spring.Objects.Factory.Support;
+
+/// <summary>
+/// Regression tests for GH-239: instances created from inner object definitions and
+/// implementing <see cref="IDisposable"/> must not accumulate in the factory-lifetime
+/// disposal registry when the owning instance is created repeatedly.
+/// </summary>
+[TestFixture]
+public sealed class DisposableInnerObjectTrackingTests
+{
+    private sealed class ExposingObjectFactory : DefaultListableObjectFactory
+    {
+        public int DisposableInnerObjectCount => DisposableInnerObjects.Count;
+    }
+
+    public sealed class DisposableInner : IDisposable
+    {
+        public bool Disposed;
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+
+    public sealed class Owner
+    {
+        public DisposableInner Inner { get; set; }
+    }
+
+    private static RootObjectDefinition OwnerDefinitionWithDisposableInner(bool singleton)
+    {
+        RootObjectDefinition owner = new RootObjectDefinition(typeof(Owner));
+        owner.IsSingleton = singleton;
+        owner.PropertyValues.Add("Inner", new RootObjectDefinition(typeof(DisposableInner)));
+        return owner;
+    }
+
+    [Test]
+    public void ConfigureObjectDoesNotAccumulateDisposableInnerObjects()
+    {
+        ExposingObjectFactory factory = new ExposingObjectFactory();
+        factory.RegisterObjectDefinition("owner", OwnerDefinitionWithDisposableInner(true));
+
+        for (int i = 0; i < 5; i++)
+        {
+            Owner owner = new Owner();
+            factory.ConfigureObject(owner, "owner");
+            Assert.That(owner.Inner, Is.Not.Null);
+        }
+
+        Assert.That(factory.DisposableInnerObjectCount, Is.EqualTo(0),
+            "ConfigureObject() configures externally managed instances and may run once per " +
+            "web request; it must not register inner objects for factory-shutdown disposal.");
+    }
+
+    [Test]
+    public void SingletonWithDisposableInnerObjectIsRegisteredExactlyOnce()
+    {
+        ExposingObjectFactory factory = new ExposingObjectFactory();
+        factory.RegisterObjectDefinition("owner", OwnerDefinitionWithDisposableInner(true));
+
+        Owner first = (Owner) factory.GetObject("owner");
+        Owner second = (Owner) factory.GetObject("owner");
+
+        Assert.That(second, Is.SameAs(first));
+        Assert.That(factory.DisposableInnerObjectCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void PrototypeWithDisposableInnerObjectIsNotRegistered()
+    {
+        ExposingObjectFactory factory = new ExposingObjectFactory();
+        factory.RegisterObjectDefinition("owner", OwnerDefinitionWithDisposableInner(false));
+
+        factory.GetObject("owner");
+        factory.GetObject("owner");
+
+        Assert.That(factory.DisposableInnerObjectCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void RegisteredInnerObjectOfSingletonIsDisposedWithTheFactory()
+    {
+        ExposingObjectFactory factory = new ExposingObjectFactory();
+        factory.RegisterObjectDefinition("owner", OwnerDefinitionWithDisposableInner(true));
+
+        Owner owner = (Owner) factory.GetObject("owner");
+        Assert.That(owner.Inner.Disposed, Is.False);
+
+        factory.Dispose();
+
+        Assert.That(owner.Inner.Disposed, Is.True);
+    }
+}

--- a/test/Spring/Spring.Web.Tests/Objects/Factory/Support/WebObjectFactoryDisposableInnerObjectTests.cs
+++ b/test/Spring/Spring.Web.Tests/Objects/Factory/Support/WebObjectFactoryDisposableInnerObjectTests.cs
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using NUnit.Framework;
+using Spring.Objects.Factory.Config;
+using Spring.TestSupport;
+
+namespace Spring.Objects.Factory.Support;
+
+/// <summary>
+/// Regression tests for GH-239: inner objects of 'request'- and 'session'-scoped owners
+/// are created anew on every request/session and must not be tracked in the
+/// factory-lifetime disposal registry.
+/// </summary>
+[TestFixture]
+public sealed class WebObjectFactoryDisposableInnerObjectTests
+{
+    private sealed class TestWebObjectFactory : WebObjectFactory
+    {
+        public TestWebObjectFactory(string contextPath, bool caseSensitive)
+            : base(contextPath, caseSensitive)
+        {
+        }
+
+        public int DisposableInnerObjectCount => DisposableInnerObjects.Count;
+
+        public void RegisterDisposableInnerObjectForTest(string ownerName, object instance)
+        {
+            RegisterDisposableInnerObject(ownerName, instance);
+        }
+    }
+
+    private sealed class DisposableInner : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+
+    private TestWebObjectFactory CreateFactoryWithScopedDefinitions()
+    {
+        TestWebObjectFactory factory;
+        using (new VirtualEnvironmentMock("/somedir/some.file", null, null, "/", true))
+        {
+            factory = new TestWebObjectFactory("/somedir/", false);
+        }
+
+        RegisterDefinition(factory, "applicationScopedOwner", ObjectScope.Application);
+        RegisterDefinition(factory, "requestScopedOwner", ObjectScope.Request);
+        RegisterDefinition(factory, "sessionScopedOwner", ObjectScope.Session);
+        return factory;
+    }
+
+    private static void RegisterDefinition(WebObjectFactory factory, string name, ObjectScope scope)
+    {
+        RootWebObjectDefinition definition = new RootWebObjectDefinition(
+            typeof(object), new ConstructorArgumentValues(), new MutablePropertyValues());
+        definition.Scope = scope.ToString();
+        factory.RegisterObjectDefinition(name, definition);
+    }
+
+    [Test]
+    public void InnerObjectsOfRequestAndSessionScopedOwnersAreNotTracked()
+    {
+        TestWebObjectFactory factory = CreateFactoryWithScopedDefinitions();
+
+        factory.RegisterDisposableInnerObjectForTest("requestScopedOwner", new DisposableInner());
+        factory.RegisterDisposableInnerObjectForTest("sessionScopedOwner", new DisposableInner());
+
+        Assert.That(factory.DisposableInnerObjectCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void InnerObjectsOfApplicationScopedOwnersAreStillTracked()
+    {
+        TestWebObjectFactory factory = CreateFactoryWithScopedDefinitions();
+
+        factory.RegisterDisposableInnerObjectForTest("applicationScopedOwner", new DisposableInner());
+
+        Assert.That(factory.DisposableInnerObjectCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void InnerObjectsOfUnknownOwnersAreStillTracked()
+    {
+        TestWebObjectFactory factory = CreateFactoryWithScopedDefinitions();
+
+        factory.RegisterDisposableInnerObjectForTest("(inner object)", new DisposableInner());
+
+        Assert.That(factory.DisposableInnerObjectCount, Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
Fixes #239

## Root cause

`ObjectDefinitionValueResolver.ResolveInnerObjectDefinition` adds every `IDisposable` instance created from an inner `<object>` definition to the factory-lifetime `DisposableInnerObjects` set whenever the *owning* definition reports `IsSingleton == true`. The set is only cleared when the factory itself is disposed.

In a web application, two owner categories satisfy `IsSingleton == true` while being **created anew on every request**:

- **Externally managed instances configured via `ConfigureObject(target, name)`** — WebForms handlers/controls/module instances are configured once per request by `WebSupportModule`, and unlike the `GetObjectInternal` argument-supplied path, `ConfigureObject` used the cached merged definition as-is, singleton flag intact.
- **`request`- and `session`-scoped web objects** — these are "web-scoped singletons" (`WebObjectFactory.IsWebScopedSingleton` requires `IsSingleton == true`), instantiated per request/session.

Every such request permanently rooted one instance per `IDisposable` inner object. EF-related types are all `IDisposable`, which matches the ANTS observations in #239 exactly: instances created per request from `WebInstantiationStrategy` (the creation stack for all container-created objects in a web context), never collected, accumulating in gen2. The logic is identical in 1.3.2 and current main.

Notably, `WebObjectFactory` already overrides `RegisterDisposableObjectIfNecessary` so web-scoped singletons stay out of the *named* disposal registry — but the parallel inner-object registry is populated from `ObjectDefinitionValueResolver`, which `WebObjectFactory` previously could not intercept.

## Fix

- `ConfigureObject(target, name)` now clones the merged definition and drops singleton semantics (`CreateRootObjectDefinition` + `IsSingleton = false`), mirroring what `GetObjectInternal` already does for argument-supplied lookups.
- Inner-object disposal registration goes through a new virtual `AbstractObjectFactory.RegisterDisposableInnerObject(ownerName, instance)` hook. `WebObjectFactory` overrides it to skip `request`-/`session`-scoped owners — the same treatment it already applies in `RegisterDisposableObjectIfNecessary`.

Behavior preserved: true singletons register their inner disposables exactly once and dispose them on factory shutdown (covered by a test).

## Verification

- Repro harness (net8.0 console against Spring.Core, simulating per-request `ConfigureObject` on a singleton-scoped definition with an `IDisposable` inner object): **before** — 50,000 simulated requests left 50,000 instances in `DisposableInnerObjects`, all surviving forced gen2 compaction; **after** — 0 retained, all weak-referenced samples collected.
- Control run of the plain instantiation chain (prototype creation, method injection, `ConfigureObject`, 200k iterations) shows no growth before or after; an ultra ETW profile of the loop confirms zero per-request dynamic code generation, ruling out the codegen-leak theory.
- `Spring.Core.Tests` (net8.0): 2461 passed, 1 failed — `FormatUsingDefaults`, a known locale-dependent local-machine failure unrelated to this change. `Spring.Web.Tests` (net462): 205 passed, 0 failed.
- New regression tests: `DisposableInnerObjectTrackingTests` (Core) and `WebObjectFactoryDisposableInnerObjectTests` (Web).

## Known limitation

Inner objects nested inside *other inner objects* of a request-/session-scoped owner use synthetic definition names that cannot be resolved back to the scoped owner, so that (rare, doubly-nested) case still registers. The dominant single-level case is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)