### PR TITLE
Add extension methods and properties to the expression language

### DIFF
--- a/doc/reference/src/expressions.xml
+++ b/doc/reference/src/expressions.xml
@@ -1034,6 +1034,128 @@ public void DoWork()
 }</programlisting>
     </sect2>
 
+    <sect2 xml:id="expressions-extensions">
+      <title>Extension Methods and Properties</title>
+
+      <para>Extension methods and extension properties allow you to attach
+      members to any type for the duration of an expression evaluation,
+      without modifying the type itself. Registration is scoped to a variables
+      dictionary -- the very same dictionary that is passed to the
+      <literal>GetValue</literal> method -- and is not global, which means that
+      different parts of an application can register different extensions
+      without interfering with one another.</para>
+
+      <para>An extension can be defined using a Spring lambda expression. The
+      first argument of the lambda receives the target instance the extension
+      was invoked on:<programlisting language="csharp">IDictionary&lt;string, object&gt; vars = new Dictionary&lt;string, object&gt;();
+vars["foo"] = new Foo(41);   // Foo has an int property InternalValue
+
+Expression.RegisterExtensionMethod&lt;Foo&gt;("AddTo", "{|self, arg| $self.InternalValue + $arg}", vars);
+ExpressionEvaluator.GetValue(null, "#foo.AddTo(1)", vars);   // 42
+
+Expression.RegisterExtensionProperty&lt;Foo&gt;("Doubled", "{|self| $self.InternalValue * 2}", vars);
+ExpressionEvaluator.GetValue(null, "#foo.Doubled", vars);    // 82</programlisting></para>
+
+      <para>Alternatively, an extension can be backed by a .NET delegate.
+      Typed <literal>Func&lt;&gt;</literal> overloads are provided for the
+      receiver plus up to three arguments, and a
+      <literal>System.Delegate</literal> overload accepts any other delegate
+      beyond that, for example one that returns <literal>void</literal> or one
+      that takes a larger number of arguments:<programlisting language="csharp">Expression.RegisterExtensionMethod("AddTo", (Foo self, int arg) =&gt; self.InternalValue + arg, vars);
+Expression.RegisterExtensionProperty("Doubled", (Foo self) =&gt; self.InternalValue * 2, vars);</programlisting></para>
+
+      <para>Non-generic overloads that take a <literal>System.Type</literal> as
+      their first parameter exist for all of the forms shown above, for example
+      <literal>Expression.RegisterExtensionMethod(typeof(Foo), ...)</literal>,
+      for the cases where the receiver type is not known at compile
+      time.</para>
+
+      <para>The following rules govern how extensions are resolved:</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>Real CLR members always win. An extension is consulted only
+          when method or property resolution finds no matching member on the
+          receiver, so an extension can never shadow a real member.</para>
+        </listitem>
+
+        <listitem>
+          <para>Registered collection processors and method call processors
+          (the pre-existing mechanism described in <xref
+          linkend="expressions-processors" />) retain their historical
+          precedence and still take priority over both CLR members and
+          extensions, whenever a variable of that name implements the
+          corresponding processor interface.</para>
+        </listitem>
+
+        <listitem>
+          <para>Lookup walks the receiver's runtime type first, then its base
+          classes, and finally the interfaces it implements. The most derived
+          registration wins. Re-registering the same name for the same type
+          replaces the previous registration.</para>
+        </listitem>
+
+        <listitem>
+          <para>Member name lookup is case-insensitive, just like regular
+          expression language member access.</para>
+        </listitem>
+
+        <listitem>
+          <para>Extensions never apply to a <literal>null</literal>
+          receiver.</para>
+        </listitem>
+
+        <listitem>
+          <para>The receiver has to be an instance. In the expression
+          <literal>Foo.AddTo(1)</literal>, where <literal>Foo</literal> is a
+          type name, no extension registered for <literal>Foo</literal>
+          applies, because the expression dispatches on runtime types only.
+          Use <literal>#foo.AddTo(1)</literal>, where <literal>foo</literal>
+          is a variable, or any other sub-expression that evaluates to a
+          <literal>Foo</literal> instance. An extension registered for
+          <literal>System.Type</literal>, on the other hand, does apply to a
+          type reference, because a type reference is itself a
+          <literal>Type</literal> instance.</para>
+        </listitem>
+
+        <listitem>
+          <para>Extension properties are read-only. Assigning to one throws a
+          <literal>NotWritablePropertyException</literal>.</para>
+        </listitem>
+
+        <listitem>
+          <para>Arguments are passed without any type conversion, exactly as
+          they are for regular method invocation.</para>
+        </listitem>
+
+        <listitem>
+          <para>A lambda literal passed as an argument reaches the extension
+          unevaluated. A lambda-based extension can invoke it using the
+          <literal>$f(...)</literal> syntax.</para>
+        </listitem>
+
+        <listitem>
+          <para>Do not give an extension property the same name as a
+          registered type alias -- a type resolution that has already been
+          cached for that name can take precedence.</para>
+        </listitem>
+
+        <listitem>
+          <para>Register all of the extensions before evaluating expressions
+          concurrently. Registration mutates the variables dictionary, which
+          is not thread-safe for concurrent writes. Once the setup is
+          complete, concurrent evaluation is safe.</para>
+        </listitem>
+      </itemizedlist>
+
+      <para>Inside a lambda-based extension the receiver is also the
+      evaluation context, so unqualified member names such as
+      <literal>InternalValue</literal> resolve against it. Global
+      <literal>#variables</literal> and the functions registered with
+      <literal>Expression.RegisterFunction</literal> remain accessible as
+      well.</para>
+    </sect2>
+
     <sect2>
       <title>Null Context</title>
 

--- a/src/Spring/Spring.Core/Expressions/Expression.cs
+++ b/src/Spring/Spring.Core/Expressions/Expression.cs
@@ -56,6 +56,11 @@ public class Expression : BaseNode
         /// variable name of the currently processed object factory, if any
         /// </summary>
         internal static readonly string CurrentObjectFactory = RESERVEDPREFIX + "CurrentObjectFactory";
+
+        /// <summary>
+        /// variable name of the registry holding user-registered extension methods and properties
+        /// </summary>
+        internal static readonly string ExpressionExtensions = RESERVEDPREFIX + "ExpressionExtensions";
     }
 
     private class ASTNodeCreator : Parser.antlr.ASTNodeCreator
@@ -169,6 +174,234 @@ public class Expression : BaseNode
         AssertUtils.ArgumentHasText(functionName, "functionName");
         AssertUtils.ArgumentHasText(lambdaExpression, "lambdaExpression");
 
+        variables[functionName] = ParseLambda(lambdaExpression);
+    }
+
+    /// <summary>
+    /// Registers an extension method for type <typeparamref name="T"/>, implemented by the
+    /// specified lambda expression. The lambda's first argument receives the target instance;
+    /// remaining arguments receive the invocation arguments.
+    /// </summary>
+    /// <typeparam name="T">Type to extend.</typeparam>
+    /// <param name="methodName">Method name to register the extension under.</param>
+    /// <param name="lambdaExpression">Lambda expression implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionMethod<T>(string methodName, string lambdaExpression, IDictionary<string, object> variables)
+    {
+        RegisterExtensionMethod(typeof(T), methodName, lambdaExpression, variables);
+    }
+
+    /// <summary>
+    /// Registers an extension method for <paramref name="targetType"/>, implemented by the
+    /// specified lambda expression. The lambda's first argument receives the target instance;
+    /// remaining arguments receive the invocation arguments.
+    /// </summary>
+    /// <param name="targetType">Type to extend.</param>
+    /// <param name="methodName">Method name to register the extension under.</param>
+    /// <param name="lambdaExpression">Lambda expression implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionMethod(Type targetType, string methodName, string lambdaExpression, IDictionary<string, object> variables)
+    {
+        AssertUtils.ArgumentNotNull(targetType, "targetType");
+        AssertUtils.ArgumentHasText(methodName, "methodName");
+        AssertUtils.ArgumentHasText(lambdaExpression, "lambdaExpression");
+        AssertUtils.ArgumentNotNull(variables, "variables");
+
+        LambdaExpressionNode lambda = ParseLambda(lambdaExpression);
+        if (lambda.ArgumentNames.Length == 0)
+        {
+            throw new ArgumentException(
+                "An extension method lambda expression must declare at least one argument to receive the target instance.",
+                "lambdaExpression");
+        }
+
+        ExpressionExtensionRegistry.Register(variables, new ExpressionExtension(targetType, methodName, lambda), false);
+    }
+
+    /// <summary>
+    /// Registers an extension method for type <typeparamref name="T"/>, implemented by the
+    /// specified delegate. The delegate's first parameter receives the target instance;
+    /// remaining parameters receive the invocation arguments.
+    /// </summary>
+    /// <typeparam name="T">Type to extend.</typeparam>
+    /// <param name="methodName">Method name to register the extension under.</param>
+    /// <param name="implementation">Delegate implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionMethod<T>(string methodName, Delegate implementation, IDictionary<string, object> variables)
+    {
+        RegisterExtensionMethod(typeof(T), methodName, implementation, variables);
+    }
+
+    /// <summary>
+    /// Registers an extension method for <paramref name="targetType"/>, implemented by the
+    /// specified delegate. The delegate's first parameter receives the target instance;
+    /// remaining parameters receive the invocation arguments.
+    /// </summary>
+    /// <param name="targetType">Type to extend.</param>
+    /// <param name="methodName">Method name to register the extension under.</param>
+    /// <param name="implementation">Delegate implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionMethod(Type targetType, string methodName, Delegate implementation, IDictionary<string, object> variables)
+    {
+        AssertUtils.ArgumentNotNull(targetType, "targetType");
+        AssertUtils.ArgumentHasText(methodName, "methodName");
+        AssertUtils.ArgumentNotNull(implementation, "implementation");
+        AssertUtils.ArgumentNotNull(variables, "variables");
+
+        AssertReceiverParameter(targetType, implementation, 0);
+
+        ExpressionExtensionRegistry.Register(variables, new ExpressionExtension(targetType, methodName, implementation), false);
+    }
+
+    /// <summary>
+    /// Registers an extension method for type <typeparamref name="T"/> that takes no arguments
+    /// beyond the target instance.
+    /// </summary>
+    public static void RegisterExtensionMethod<T, TResult>(string methodName, Func<T, TResult> implementation, IDictionary<string, object> variables)
+    {
+        RegisterExtensionMethod(typeof(T), methodName, (Delegate) implementation, variables);
+    }
+
+    /// <summary>
+    /// Registers an extension method for type <typeparamref name="T"/> that takes one argument
+    /// beyond the target instance.
+    /// </summary>
+    public static void RegisterExtensionMethod<T, TArg1, TResult>(string methodName, Func<T, TArg1, TResult> implementation, IDictionary<string, object> variables)
+    {
+        RegisterExtensionMethod(typeof(T), methodName, (Delegate) implementation, variables);
+    }
+
+    /// <summary>
+    /// Registers an extension method for type <typeparamref name="T"/> that takes two arguments
+    /// beyond the target instance.
+    /// </summary>
+    public static void RegisterExtensionMethod<T, TArg1, TArg2, TResult>(string methodName, Func<T, TArg1, TArg2, TResult> implementation, IDictionary<string, object> variables)
+    {
+        RegisterExtensionMethod(typeof(T), methodName, (Delegate) implementation, variables);
+    }
+
+    /// <summary>
+    /// Registers an extension method for type <typeparamref name="T"/> that takes three arguments
+    /// beyond the target instance.
+    /// </summary>
+    public static void RegisterExtensionMethod<T, TArg1, TArg2, TArg3, TResult>(string methodName, Func<T, TArg1, TArg2, TArg3, TResult> implementation, IDictionary<string, object> variables)
+    {
+        RegisterExtensionMethod(typeof(T), methodName, (Delegate) implementation, variables);
+    }
+
+    /// <summary>
+    /// Registers a read-only extension property for type <typeparamref name="T"/>, implemented
+    /// by the specified lambda expression. The lambda must declare exactly one argument, which
+    /// receives the target instance.
+    /// </summary>
+    /// <typeparam name="T">Type to extend.</typeparam>
+    /// <param name="propertyName">Property name to register the extension under.</param>
+    /// <param name="lambdaExpression">Lambda expression implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionProperty<T>(string propertyName, string lambdaExpression, IDictionary<string, object> variables)
+    {
+        RegisterExtensionProperty(typeof(T), propertyName, lambdaExpression, variables);
+    }
+
+    /// <summary>
+    /// Registers a read-only extension property for <paramref name="targetType"/>, implemented
+    /// by the specified lambda expression. The lambda must declare exactly one argument, which
+    /// receives the target instance.
+    /// </summary>
+    /// <param name="targetType">Type to extend.</param>
+    /// <param name="propertyName">Property name to register the extension under.</param>
+    /// <param name="lambdaExpression">Lambda expression implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionProperty(Type targetType, string propertyName, string lambdaExpression, IDictionary<string, object> variables)
+    {
+        AssertUtils.ArgumentNotNull(targetType, "targetType");
+        AssertUtils.ArgumentHasText(propertyName, "propertyName");
+        AssertUtils.ArgumentHasText(lambdaExpression, "lambdaExpression");
+        AssertUtils.ArgumentNotNull(variables, "variables");
+
+        LambdaExpressionNode lambda = ParseLambda(lambdaExpression);
+        if (lambda.ArgumentNames.Length != 1)
+        {
+            throw new ArgumentException(
+                "An extension property lambda expression must declare exactly one argument to receive the target instance.",
+                "lambdaExpression");
+        }
+
+        ExpressionExtensionRegistry.Register(variables, new ExpressionExtension(targetType, propertyName, lambda), true);
+    }
+
+    /// <summary>
+    /// Registers a read-only extension property for type <typeparamref name="T"/>, implemented
+    /// by the specified delegate. The delegate must declare exactly one parameter, which
+    /// receives the target instance.
+    /// </summary>
+    /// <typeparam name="T">Type to extend.</typeparam>
+    /// <param name="propertyName">Property name to register the extension under.</param>
+    /// <param name="implementation">Delegate implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionProperty<T>(string propertyName, Delegate implementation, IDictionary<string, object> variables)
+    {
+        RegisterExtensionProperty(typeof(T), propertyName, implementation, variables);
+    }
+
+    /// <summary>
+    /// Registers a read-only extension property for <paramref name="targetType"/>, implemented
+    /// by the specified delegate. The delegate must declare exactly one parameter, which
+    /// receives the target instance.
+    /// </summary>
+    /// <param name="targetType">Type to extend.</param>
+    /// <param name="propertyName">Property name to register the extension under.</param>
+    /// <param name="implementation">Delegate implementing the extension.</param>
+    /// <param name="variables">Variables dictionary that the extension will be registered in.</param>
+    public static void RegisterExtensionProperty(Type targetType, string propertyName, Delegate implementation, IDictionary<string, object> variables)
+    {
+        AssertUtils.ArgumentNotNull(targetType, "targetType");
+        AssertUtils.ArgumentHasText(propertyName, "propertyName");
+        AssertUtils.ArgumentNotNull(implementation, "implementation");
+        AssertUtils.ArgumentNotNull(variables, "variables");
+
+        AssertReceiverParameter(targetType, implementation, 1);
+
+        ExpressionExtensionRegistry.Register(variables, new ExpressionExtension(targetType, propertyName, implementation), true);
+    }
+
+    /// <summary>
+    /// Registers a read-only extension property for type <typeparamref name="T"/>, implemented
+    /// by the specified function.
+    /// </summary>
+    public static void RegisterExtensionProperty<T, TResult>(string propertyName, Func<T, TResult> implementation, IDictionary<string, object> variables)
+    {
+        RegisterExtensionProperty(typeof(T), propertyName, (Delegate) implementation, variables);
+    }
+
+    private static void AssertReceiverParameter(Type targetType, Delegate implementation, int requiredParameterCount)
+    {
+        ParameterInfo[] parameters = implementation.Method.GetParameters();
+
+        if (parameters.Length == 0)
+        {
+            throw new ArgumentException(
+                "An extension delegate must declare at least one parameter to receive the target instance.",
+                "implementation");
+        }
+
+        if (requiredParameterCount > 0 && parameters.Length != requiredParameterCount)
+        {
+            throw new ArgumentException(string.Format(
+                "An extension property delegate must declare exactly {0} parameter(s), but declares {1}.",
+                requiredParameterCount, parameters.Length), "implementation");
+        }
+
+        if (!parameters[0].ParameterType.IsAssignableFrom(targetType))
+        {
+            throw new ArgumentException(string.Format(
+                "The first parameter of an extension delegate must be assignable from the extended type '{0}', but was '{1}'.",
+                targetType.FullName, parameters[0].ParameterType.FullName), "implementation");
+        }
+    }
+
+    private static LambdaExpressionNode ParseLambda(string lambdaExpression)
+    {
         ExpressionLexer lexer = new ExpressionLexer(new StringReader(lambdaExpression));
         ExpressionParser parser = new SpringExpressionParser(lexer);
 
@@ -181,7 +414,7 @@ public class Expression : BaseNode
             throw new SyntaxErrorException(ex.recog.Message, ex.recog.getLine(), ex.recog.getColumn(), lambdaExpression);
         }
 
-        variables[functionName] = parser.getAST();
+        return (LambdaExpressionNode) parser.getAST();
     }
 
     /// <summary>

--- a/src/Spring/Spring.Core/Expressions/ExpressionExtension.cs
+++ b/src/Spring/Spring.Core/Expressions/ExpressionExtension.cs
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Spring.Reflection.Dynamic;
+
+namespace Spring.Expressions;
+
+/// <summary>
+/// Represents a single extension method or extension property registered for a type
+/// via <see cref="Expression.RegisterExtensionMethod(Type, string, Delegate, System.Collections.Generic.IDictionary{string, object})"/>
+/// and its sibling overloads. The implementation is either a parsed lambda expression
+/// or a .NET delegate; in both cases the receiver is passed as the first argument.
+/// </summary>
+[Serializable]
+internal sealed class ExpressionExtension
+{
+    private readonly Type targetType;
+    private readonly string name;
+    private readonly LambdaExpressionNode lambdaExpression;
+    private readonly Delegate callback;
+    private readonly int parameterCount;
+
+    public ExpressionExtension(Type targetType, string name, LambdaExpressionNode lambdaExpression)
+    {
+        this.targetType = targetType;
+        this.name = name;
+        this.lambdaExpression = lambdaExpression;
+        this.parameterCount = lambdaExpression.ArgumentNames.Length;
+    }
+
+    public ExpressionExtension(Type targetType, string name, Delegate callback)
+    {
+        this.targetType = targetType;
+        this.name = name;
+        this.callback = callback;
+        this.parameterCount = callback.Method.GetParameters().Length;
+    }
+
+    /// <summary>
+    /// Gets the type this extension was registered for.
+    /// </summary>
+    public Type TargetType
+    {
+        get { return targetType; }
+    }
+
+    /// <summary>
+    /// Gets the member name this extension was registered under.
+    /// </summary>
+    public string Name
+    {
+        get { return name; }
+    }
+
+    /// <summary>
+    /// Gets the lambda expression implementing this extension, or <c>null</c> for the delegate form.
+    /// </summary>
+    public LambdaExpressionNode LambdaExpression
+    {
+        get { return lambdaExpression; }
+    }
+
+    /// <summary>
+    /// Ensures the number of invocation arguments (including the receiver) matches the
+    /// registered implementation.
+    /// </summary>
+    /// <exception cref="ArgumentException">If the argument count does not match.</exception>
+    public void AssertArgumentCount(int argumentCount)
+    {
+        if (argumentCount != parameterCount)
+        {
+            throw new ArgumentException(string.Format(
+                "Extension '{0}' registered for type '{1}' expects {2} argument(s) including the receiver, but was called with {3}.",
+                name, targetType.FullName, parameterCount, argumentCount));
+        }
+    }
+
+    /// <summary>
+    /// Invokes the delegate form of this extension. Only valid when <see cref="LambdaExpression"/> is <c>null</c>.
+    /// </summary>
+    public object InvokeCallback(object[] arguments)
+    {
+        return new SafeMethod(callback.Method).Invoke(callback.Target, arguments);
+    }
+}

--- a/src/Spring/Spring.Core/Expressions/ExpressionExtensionRegistry.cs
+++ b/src/Spring/Spring.Core/Expressions/ExpressionExtensionRegistry.cs
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Spring.Expressions;
+
+/// <summary>
+/// Holds the extension methods and extension properties registered against a variables
+/// dictionary. A single registry instance is stored in the dictionary under the reserved
+/// <see cref="Expression.ReservedVariableNames.ExpressionExtensions"/> key, so registrations
+/// are scoped to the dictionary they were made against.
+/// </summary>
+/// <remarks>
+/// Lookups are lock-free: both tables are immutable once published and replaced wholesale
+/// (copy-on-write) on registration, so concurrent evaluation never observes a table under
+/// mutation. The <see cref="hasInterfaceRegistrations"/> flag is written before the table
+/// that contains the interface registration is published, so any reader that sees the new
+/// table also performs the interface walk.
+/// </remarks>
+[Serializable]
+internal sealed class ExpressionExtensionRegistry
+{
+    [Serializable]
+    private readonly struct ExtensionKey : IEquatable<ExtensionKey>
+    {
+        private readonly Type type;
+        private readonly string name;
+
+        public ExtensionKey(Type type, string name)
+        {
+            this.type = type;
+            this.name = name;
+        }
+
+        public bool Equals(ExtensionKey other)
+        {
+            return type == other.type && string.Equals(name, other.name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ExtensionKey && Equals((ExtensionKey) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return unchecked((type.GetHashCode() * 397) ^ StringComparer.OrdinalIgnoreCase.GetHashCode(name));
+        }
+    }
+
+    private static readonly object registrationLock = new object();
+
+    private readonly object syncRoot = new object();
+
+    private volatile Dictionary<ExtensionKey, ExpressionExtension> methods = new Dictionary<ExtensionKey, ExpressionExtension>();
+    private volatile Dictionary<ExtensionKey, ExpressionExtension> properties = new Dictionary<ExtensionKey, ExpressionExtension>();
+    private volatile bool hasInterfaceRegistrations;
+
+    /// <summary>
+    /// Registers an extension in the registry stored in <paramref name="variables"/>,
+    /// creating the registry on first use. A later registration for the same type and
+    /// name replaces the earlier one.
+    /// </summary>
+    public static void Register(IDictionary<string, object> variables, ExpressionExtension extension, bool isProperty)
+    {
+        ExpressionExtensionRegistry registry;
+        lock (registrationLock)
+        {
+            object existing;
+            variables.TryGetValue(Expression.ReservedVariableNames.ExpressionExtensions, out existing);
+            registry = existing as ExpressionExtensionRegistry;
+            if (registry == null)
+            {
+                registry = new ExpressionExtensionRegistry();
+                variables[Expression.ReservedVariableNames.ExpressionExtensions] = registry;
+            }
+        }
+
+        registry.Add(extension, isProperty);
+    }
+
+    /// <summary>
+    /// Finds the extension method registered for the runtime type of <paramref name="context"/>
+    /// under <paramref name="name"/>, or <c>null</c>.
+    /// </summary>
+    public static ExpressionExtension FindMethod(IDictionary<string, object> variables, object context, string name)
+    {
+        return Find(variables, context, name, false);
+    }
+
+    /// <summary>
+    /// Finds the extension property registered for the runtime type of <paramref name="context"/>
+    /// under <paramref name="name"/>, or <c>null</c>.
+    /// </summary>
+    public static ExpressionExtension FindProperty(IDictionary<string, object> variables, object context, string name)
+    {
+        return Find(variables, context, name, true);
+    }
+
+    private static ExpressionExtension Find(IDictionary<string, object> variables, object context, string name, bool isProperty)
+    {
+        if (context == null || variables == null || variables.Count == 0)
+        {
+            return null;
+        }
+
+        object value;
+        variables.TryGetValue(Expression.ReservedVariableNames.ExpressionExtensions, out value);
+        ExpressionExtensionRegistry registry = value as ExpressionExtensionRegistry;
+        if (registry == null)
+        {
+            return null;
+        }
+
+        return registry.Find(context.GetType(), name, isProperty);
+    }
+
+    private ExpressionExtension Find(Type contextType, string name, bool isProperty)
+    {
+        Dictionary<ExtensionKey, ExpressionExtension> table = isProperty ? properties : methods;
+        if (table.Count == 0)
+        {
+            return null;
+        }
+
+        ExpressionExtension extension;
+        for (Type type = contextType; type != null; type = type.BaseType)
+        {
+            if (table.TryGetValue(new ExtensionKey(type, name), out extension))
+            {
+                return extension;
+            }
+        }
+
+        if (hasInterfaceRegistrations)
+        {
+            Type[] interfaces = contextType.GetInterfaces();
+            for (int i = 0; i < interfaces.Length; i++)
+            {
+                if (table.TryGetValue(new ExtensionKey(interfaces[i], name), out extension))
+                {
+                    return extension;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private void Add(ExpressionExtension extension, bool isProperty)
+    {
+        lock (syncRoot)
+        {
+            if (extension.TargetType.IsInterface)
+            {
+                hasInterfaceRegistrations = true;
+            }
+
+            Dictionary<ExtensionKey, ExpressionExtension> copy =
+                new Dictionary<ExtensionKey, ExpressionExtension>(isProperty ? properties : methods);
+            copy[new ExtensionKey(extension.TargetType, extension.Name)] = extension;
+
+            if (isProperty)
+            {
+                properties = copy;
+            }
+            else
+            {
+                methods = copy;
+            }
+        }
+    }
+}

--- a/src/Spring/Spring.Core/Expressions/MethodNode.cs
+++ b/src/Spring/Spring.Core/Expressions/MethodNode.cs
@@ -129,7 +129,7 @@ public class MethodNode : NodeWithArguments
                 // calculate checksum, if the cached method matches the current context
                 if (initialized)
                 {
-                    int calculatedHash = CalculateMethodHash(context.GetType(), argValues);
+                    int calculatedHash = CalculateMethodHash(GetContextType(context), argValues);
                     initialized = (calculatedHash == cachedInstanceMethodHash);
                 }
 
@@ -158,6 +158,26 @@ public class MethodNode : NodeWithArguments
         }
         else
         {
+            // as a last resort, try a user-registered extension method; this is deliberately
+            // consulted only when no CLR method matches, so an extension can never shadow a
+            // real method
+            ExpressionExtension extension = ExpressionExtensionRegistry.FindMethod(evalContext.Variables, context, methodName);
+            if (extension != null)
+            {
+                object[] extensionArgs = new object[argValues.Length + 1];
+                extensionArgs[0] = context;
+                Array.Copy(argValues, 0, extensionArgs, 1, argValues.Length);
+
+                extension.AssertArgumentCount(extensionArgs.Length);
+
+                if (extension.LambdaExpression != null)
+                {
+                    return GetValueWithArguments(extension.LambdaExpression, context, evalContext, extensionArgs);
+                }
+
+                return extension.InvokeCallback(extensionArgs);
+            }
+
             throw new ArgumentException(string.Format("Method '{0}' with the specified number and types of arguments does not exist.", methodName));
         }
     }
@@ -179,9 +199,14 @@ public class MethodNode : NodeWithArguments
         return hash.ToHashCode();
     }
 
+    private static Type GetContextType(object context)
+    {
+        return context is Type ? (Type) context : context.GetType();
+    }
+
     private void Initialize(string methodName, object[] argValues, object context)
     {
-        Type contextType = (context is Type ? context as Type : context.GetType());
+        Type contextType = GetContextType(context);
 
         // check the context type first
         MethodInfo mi = GetBestMethod(contextType, methodName, BINDING_FLAGS, argValues);
@@ -194,6 +219,14 @@ public class MethodNode : NodeWithArguments
 
         if (mi == null)
         {
+            // make sure a method cached for a previously seen context type is not reused,
+            // and remember the negative result so the reflection probe is not repeated for
+            // the same context and argument types
+            cachedInstanceMethod = null;
+            cachedIsParamArray = false;
+            paramArrayType = null;
+            argumentCount = 0;
+            cachedInstanceMethodHash = CalculateMethodHash(contextType, argValues);
             return;
         }
         else

--- a/src/Spring/Spring.Core/Expressions/PropertyOrFieldNode.cs
+++ b/src/Spring/Spring.Core/Expressions/PropertyOrFieldNode.cs
@@ -61,7 +61,11 @@ public class PropertyOrFieldNode : BaseNode
     /// Initializes the node.
     /// </summary>
     /// <param name="context">The parent.</param>
-    private void InitializeNode(object context)
+    /// <param name="evalContext">
+    /// Current expression evaluation context, or <c>null</c> when the caller cannot provide
+    /// one, in which case extension properties are not considered.
+    /// </param>
+    private void InitializeNode(object context, EvaluationContext evalContext)
     {
         Type contextType = (context == null || context is Type ? context as Type : context.GetType());
 
@@ -114,6 +118,17 @@ public class PropertyOrFieldNode : BaseNode
                     {
                         accessor = GetPropertyOrFieldAccessor(typeof(Type), memberName, BINDING_FLAGS);
                     }
+                }
+            }
+
+            // then try a user-registered extension property; this takes precedence over the
+            // type accessor below, but never over a real property or field
+            if (accessor == null && evalContext != null)
+            {
+                ExpressionExtension extension = ExpressionExtensionRegistry.FindProperty(evalContext.Variables, context, memberName);
+                if (extension != null)
+                {
+                    accessor = new ExtensionPropertyValueAccessor(extension);
                 }
             }
 
@@ -216,13 +231,19 @@ public class PropertyOrFieldNode : BaseNode
     {
         lock (this)
         {
-            InitializeNode(context);
+            InitializeNode(context, evalContext);
 
             if (context == null && accessor.RequiresContext)
             {
                 throw new NullValueInNestedPathException(
                     "Cannot retrieve the value of a field or property '" + this.memberName
                                                                          + "', because context for its resolution is null.");
+            }
+
+            ExtensionPropertyValueAccessor extensionAccessor = accessor as ExtensionPropertyValueAccessor;
+            if (extensionAccessor != null)
+            {
+                return GetExtensionPropertyValue(extensionAccessor.Extension, context, evalContext);
             }
 
             if (IsProperty || IsField)
@@ -246,7 +267,7 @@ public class PropertyOrFieldNode : BaseNode
     {
         lock (this)
         {
-            InitializeNode(context);
+            InitializeNode(context, evalContext);
 
             if (context == null && accessor.RequiresContext)
             {
@@ -316,6 +337,27 @@ public class PropertyOrFieldNode : BaseNode
                 "Illegal attempt to get value for the property '" + this.memberName +
                 "'.", e);
         }
+    }
+
+    /// <summary>
+    /// Retrieves the value of an extension property by invoking its registered
+    /// implementation with the current context as the single argument.
+    /// </summary>
+    /// <param name="extension">Extension to evaluate.</param>
+    /// <param name="context">Context to evaluate expressions against.</param>
+    /// <param name="evalContext">Current expression evaluation context.</param>
+    /// <returns>Extension property value.</returns>
+    private object GetExtensionPropertyValue(ExpressionExtension extension, object context, EvaluationContext evalContext)
+    {
+        object[] arguments = new object[] { context };
+        extension.AssertArgumentCount(arguments.Length);
+
+        if (extension.LambdaExpression != null)
+        {
+            return GetValueWithArguments(extension.LambdaExpression, context, evalContext, arguments);
+        }
+
+        return extension.InvokeCallback(arguments);
     }
 
     /// <summary>
@@ -478,7 +520,9 @@ public class PropertyOrFieldNode : BaseNode
     {
         lock (this)
         {
-            InitializeNode(context);
+            // no evaluation context is available here, so extension properties are never
+            // resolved through this path - callers expect a real PropertyInfo
+            InitializeNode(context, null);
         }
 
         return accessor.MemberInfo;
@@ -773,6 +817,46 @@ public class PropertyOrFieldNode : BaseNode
         public override void Set(object context, object value)
         {
             throw new NotSupportedException("Cannot set the value of a type.");
+        }
+    }
+
+    private class ExtensionPropertyValueAccessor : BaseValueAccessor
+    {
+        private readonly ExpressionExtension extension;
+
+        public ExtensionPropertyValueAccessor(ExpressionExtension extension)
+        {
+            this.extension = extension;
+        }
+
+        public ExpressionExtension Extension
+        {
+            get { return extension; }
+        }
+
+        public override object Get(object context)
+        {
+            // extension properties need the current evaluation context and are therefore
+            // evaluated by PropertyOrFieldNode itself
+            throw new NotSupportedException("Extension properties cannot be evaluated without an evaluation context.");
+        }
+
+        public override void Set(object context, object value)
+        {
+            throw new NotWritablePropertyException(
+                "Can't change the value of the read-only extension property '" + extension.Name + "'.");
+        }
+
+        public override bool RequiresContext
+        {
+            get { return true; }
+        }
+
+        public override bool RequiresRefresh(Type contextType)
+        {
+            // whether an extension property applies depends on the variables dictionary of
+            // the current evaluation, which is not visible here, so never cache the resolution
+            return true;
         }
     }
 }

--- a/test/Spring/Spring.Core.Tests/Expressions/ExpressionExtensionTests.cs
+++ b/test/Spring/Spring.Core.Tests/Expressions/ExpressionExtensionTests.cs
@@ -1,0 +1,489 @@
+/*
+ * Copyright © 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using NUnit.Framework;
+using Spring.Core;
+using Spring.Core.TypeResolution;
+using Spring.Expressions.Processors;
+
+namespace Spring.Expressions;
+
+/// <summary>
+/// Tests the behavior of user-registrable extension methods and extension properties.
+/// </summary>
+[TestFixture]
+public class ExpressionExtensionTests
+{
+    private const string SpelExtensionLambda = "{|self, arg| $self.InternalValue + $arg}";
+    private const string DoubledLambda = "{|self| $self.InternalValue * 2}";
+    private const string FooTypeAlias = "ExtensionTestFoo";
+
+    [Test]
+    public void LambdaExtensionMethodIsInvoked()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        Assert.AreEqual(42, ExpressionEvaluator.GetValue(null, "#foo.SpelExtension(1)", vars));
+    }
+
+    [Test]
+    public void DelegateExtensionMethodIsInvoked()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod("SpelExtension", (Foo self, int arg) => self.InternalValue + arg, vars);
+
+        Assert.AreEqual(42, ExpressionEvaluator.GetValue(null, "#foo.SpelExtension(1)", vars));
+    }
+
+    [Test]
+    public void ExtensionMethodWithoutArguments()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("Doubled", DoubledLambda, vars);
+
+        Assert.AreEqual(82, ExpressionEvaluator.GetValue(null, "#foo.Doubled()", vars));
+    }
+
+    [Test]
+    public void ExtensionMethodOnIntermediateExpressionValue()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+        Holder holder = new Holder();
+        holder.Child = CreateFoo();
+        vars["holder"] = holder;
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        Assert.AreEqual(42, ExpressionEvaluator.GetValue(null, "#holder.Child.SpelExtension(1)", vars));
+    }
+
+    [Test]
+    public void ExtensionPropertyIsResolved()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionProperty<Foo>("Doubled", DoubledLambda, vars);
+
+        Assert.AreEqual(82, ExpressionEvaluator.GetValue(null, "#foo.Doubled", vars));
+    }
+
+    [Test]
+    public void DelegateExtensionPropertyIsResolved()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionProperty("Doubled", (Foo self) => self.InternalValue * 2, vars);
+
+        Assert.AreEqual(82, ExpressionEvaluator.GetValue(null, "#foo.Doubled", vars));
+    }
+
+    [Test]
+    public void RealMethodIsNotShadowedByExtension()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("ToString", "{|self| 'fake'}", vars);
+
+        Assert.AreEqual("real", ExpressionEvaluator.GetValue(null, "#foo.ToString()", vars));
+    }
+
+    [Test]
+    public void RealPropertyIsNotShadowedByExtension()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionProperty<Foo>("InternalValue", "{|self| 999}", vars);
+
+        Assert.AreEqual(41, ExpressionEvaluator.GetValue(null, "#foo.InternalValue", vars));
+    }
+
+    [Test]
+    public void LegacyMethodCallProcessorStillWins()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        vars["Clash"] = new MyTestMethodCallProcessor();
+        Expression.RegisterExtensionMethod<Foo>("Clash", "{|self| 'extension'}", vars);
+
+        Assert.AreEqual("processor", ExpressionEvaluator.GetValue(null, "#foo.Clash()", vars));
+    }
+
+    [Test]
+    public void UnregisteredMethodStillThrowsIdenticalArgumentException()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => ExpressionEvaluator.GetValue(null, "#foo.NoSuchMethod()", vars));
+        Assert.AreEqual(MissingMethodMessage("NoSuchMethod"), ex.Message);
+    }
+
+    [Test]
+    public void UnregisteredMethodWithoutRegistryStillThrows()
+    {
+        Foo foo = CreateFoo();
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+        vars["foo"] = foo;
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => ExpressionEvaluator.GetValue(null, "#foo.NoSuchMethod()", vars));
+        Assert.AreEqual(MissingMethodMessage("NoSuchMethod"), ex.Message);
+
+        IExpression expression = Expression.Parse("NoSuchMethod()");
+        ArgumentException nullVarsEx = Assert.Throws<ArgumentException>(() => expression.GetValue(foo, null));
+        Assert.AreEqual(MissingMethodMessage("NoSuchMethod"), nullVarsEx.Message);
+    }
+
+    [Test]
+    public void UnregisteredPropertyStillThrowsInvalidPropertyException()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionProperty<Foo>("Doubled", DoubledLambda, vars);
+
+        InvalidPropertyException ex = Assert.Throws<InvalidPropertyException>(() => ExpressionEvaluator.GetValue(null, "#foo.NoSuchProp", vars));
+        Assert.IsNotNull(ex);
+        Assert.IsTrue(ex.Message.Contains("NoSuchProp"), ex.Message);
+    }
+
+    [Test]
+    public void ExtensionMethodDoesNotLeakAcrossVariableDictionaries()
+    {
+        Foo foo = CreateFoo();
+        IExpression expression = Expression.Parse("#foo.SpelExtension(1)");
+
+        Dictionary<string, object> varsA = new Dictionary<string, object>();
+        varsA["foo"] = foo;
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, varsA);
+
+        Dictionary<string, object> varsB = new Dictionary<string, object>();
+        varsB["foo"] = foo;
+
+        Assert.AreEqual(42, expression.GetValue(null, varsA));
+        Assert.Throws<ArgumentException>(() => expression.GetValue(null, varsB));
+        Assert.AreEqual(42, expression.GetValue(null, varsA));
+    }
+
+    [Test]
+    public void ExtensionPropertyDoesNotLeakAcrossVariableDictionaries()
+    {
+        Foo foo = CreateFoo();
+        IExpression expression = Expression.Parse("#foo.Doubled");
+
+        Dictionary<string, object> varsA = new Dictionary<string, object>();
+        varsA["foo"] = foo;
+        Expression.RegisterExtensionProperty<Foo>("Doubled", DoubledLambda, varsA);
+
+        Dictionary<string, object> varsB = new Dictionary<string, object>();
+        varsB["foo"] = foo;
+
+        Assert.AreEqual(82, expression.GetValue(null, varsA));
+        Assert.Throws<InvalidPropertyException>(() => expression.GetValue(null, varsB));
+        Assert.AreEqual(82, expression.GetValue(null, varsA));
+    }
+
+    [Test]
+    public void ExtensionIsIgnoredWhenVariablesAreNull()
+    {
+        Foo foo = CreateFoo();
+
+        IExpression methodExpression = Expression.Parse("SpelExtension(1)");
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => methodExpression.GetValue(foo, null));
+        Assert.AreEqual(MissingMethodMessage("SpelExtension"), ex.Message);
+
+        IExpression propertyExpression = Expression.Parse("Doubled");
+        Assert.Throws<InvalidPropertyException>(() => propertyExpression.GetValue(foo, null));
+    }
+
+    [Test]
+    public void ExtensionIsNotResolvedForTypeContext()
+    {
+        TypeRegistry.RegisterType(FooTypeAlias, typeof(Foo));
+
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        Assert.Throws<ArgumentException>(() => ExpressionEvaluator.GetValue(null, "ExtensionTestFoo.SpelExtension(1)", vars));
+    }
+
+    [Test]
+    public void ExtensionRegisteredForSystemTypeAppliesToTypeContext()
+    {
+        TypeRegistry.RegisterType(FooTypeAlias, typeof(Foo));
+
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+        Expression.RegisterExtensionMethod<Type>("Describe", "{|self| $self.Name}", vars);
+
+        Assert.AreEqual("Foo", ExpressionEvaluator.GetValue(null, "ExtensionTestFoo.Describe()", vars));
+    }
+
+    [Test]
+    public void ExtensionRegisteredOnBaseClassAppliesToDerivedType()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+        Bar bar = new Bar();
+        bar.InternalValue = 41;
+        vars["bar"] = bar;
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        Assert.AreEqual(42, ExpressionEvaluator.GetValue(null, "#bar.SpelExtension(1)", vars));
+    }
+
+    [Test]
+    public void ExtensionRegisteredOnInterfaceAppliesToImplementation()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+        Baz baz = new Baz();
+        baz.InternalValue = 41;
+        vars["baz"] = baz;
+        Expression.RegisterExtensionMethod(typeof(IHasValue), "SpelExtension", SpelExtensionLambda, vars);
+
+        Assert.AreEqual(42, ExpressionEvaluator.GetValue(null, "#baz.SpelExtension(1)", vars));
+    }
+
+    [Test]
+    public void MostDerivedRegistrationWins()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+        Bar bar = new Bar();
+        bar.InternalValue = 41;
+        vars["bar"] = bar;
+        Expression.RegisterExtensionMethod<Foo>("Which", "{|self| 'base'}", vars);
+        Expression.RegisterExtensionMethod<Bar>("Which", "{|self| 'derived'}", vars);
+
+        Assert.AreEqual("derived", ExpressionEvaluator.GetValue(null, "#bar.Which()", vars));
+    }
+
+    [Test]
+    public void ExtensionLookupIsCaseInsensitive()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        Assert.AreEqual(42, ExpressionEvaluator.GetValue(null, "#foo.spelextension(1)", vars));
+    }
+
+    [Test]
+    public void ExtensionLambdaResolvesUnqualifiedMembersAgainstReceiver()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("Bumped", "{|self| InternalValue + 1}", vars);
+
+        Assert.AreEqual(42, ExpressionEvaluator.GetValue(null, "#foo.Bumped()", vars));
+    }
+
+    [Test]
+    public void ExtensionLambdaSeesGlobalFunctionsAndVariables()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        vars["offset"] = 1;
+        Expression.RegisterFunction("triple", "{|n| $n * 3}", vars);
+        Expression.RegisterExtensionMethod<Foo>("Tripled", "{|self| #triple($self.InternalValue) + #offset}", vars);
+
+        Assert.AreEqual(124, ExpressionEvaluator.GetValue(null, "#foo.Tripled()", vars));
+    }
+
+    [Test]
+    public void ExtensionLambdaReceivesLambdaArgumentUnevaluated()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("Apply", "{|self, f| $f($self.InternalValue)}", vars);
+
+        Assert.AreEqual(82, ExpressionEvaluator.GetValue(null, "#foo.Apply({|n| $n * 2})", vars));
+    }
+
+    [Test]
+    public void ExtensionMethodWithWrongArgumentCountThrowsArgumentException()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => ExpressionEvaluator.GetValue(null, "#foo.SpelExtension()", vars));
+        Assert.AreEqual(ArityMessage("SpelExtension", typeof(Foo), 2, 1), ex.Message);
+    }
+
+    [Test]
+    public void ExtensionDelegateWithWrongArgumentCountThrowsArgumentException()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod("SpelExtension", (Foo self, int arg) => self.InternalValue + arg, vars);
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => ExpressionEvaluator.GetValue(null, "#foo.SpelExtension()", vars));
+        Assert.AreEqual(ArityMessage("SpelExtension", typeof(Foo), 2, 1), ex.Message);
+    }
+
+    [Test]
+    public void RegisteringDelegateWithoutParametersThrows()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionMethod<Foo>("X", (Delegate) new Func<int>(() => 42), vars));
+    }
+
+    [Test]
+    public void RegisteringDelegateWithIncompatibleReceiverThrows()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionMethod(typeof(Foo), "X", new Func<string, int>(s => 1), vars));
+    }
+
+    [Test]
+    public void RegisteringPropertyLambdaWithWrongArityThrows()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionProperty<Foo>("P", "{|a, b| 1}", vars));
+    }
+
+    [Test]
+    public void RegisterExtensionMethodValidatesArguments()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionMethod<Foo>(null, DoubledLambda, vars));
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionMethod<Foo>(string.Empty, DoubledLambda, vars));
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionMethod<Foo>("X", (string) null, vars));
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionMethod<Foo>("X", DoubledLambda, null));
+        Assert.Catch<ArgumentException>(() => Expression.RegisterExtensionMethod(null, "X", DoubledLambda, vars));
+    }
+
+    [Test]
+    public void InvalidLambdaExpressionThrowsSyntaxErrorException()
+    {
+        Dictionary<string, object> vars = new Dictionary<string, object>();
+
+        // Spring.Expressions.SyntaxErrorException is internal to Spring.Core, so it cannot be
+        // named here - assert on the concrete runtime type instead.
+        Exception ex = Assert.Catch(() => Expression.RegisterExtensionMethod<Foo>("X", "{|self ", vars));
+        Assert.AreEqual("Spring.Expressions.SyntaxErrorException", ex.GetType().FullName);
+    }
+
+    [Test]
+    public void SettingExtensionPropertyThrowsNotWritablePropertyException()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionProperty<Foo>("Doubled", DoubledLambda, vars);
+
+        Assert.Throws<NotWritablePropertyException>(() => ExpressionEvaluator.SetValue(null, "#foo.Doubled", vars, 1));
+    }
+
+    [Test]
+    public void ReRegisteringReplacesPreviousExtension()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("V", "{|self| 1}", vars);
+        Expression.RegisterExtensionMethod<Foo>("V", "{|self| 2}", vars);
+
+        Assert.AreEqual(2, ExpressionEvaluator.GetValue(null, "#foo.V()", vars));
+    }
+
+    [Test]
+    public void RegistryIsStoredUnderReservedVariableName()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        Assert.AreEqual(2, vars.Count);
+
+        int reservedKeys = 0;
+        foreach (string key in vars.Keys)
+        {
+            if (key.StartsWith(Expression.ReservedVariableNames.RESERVEDPREFIX, StringComparison.Ordinal))
+            {
+                reservedKeys++;
+            }
+        }
+
+        Assert.AreEqual(1, reservedKeys);
+        Assert.AreEqual(41, ExpressionEvaluator.GetValue(null, "#foo.InternalValue", vars));
+    }
+
+    [Test]
+    public void ConcurrentEvaluationOfSharedExpressionIsSafe()
+    {
+        Dictionary<string, object> vars = CreateVariables();
+        Expression.RegisterExtensionMethod<Foo>("SpelExtension", SpelExtensionLambda, vars);
+
+        IExpression expression = Expression.Parse("#foo.SpelExtension(1)");
+        int[] failures = new int[1];
+
+        Parallel.For(0, 1000, delegate(int i)
+        {
+            object result = expression.GetValue(null, vars);
+            if (!Equals(42, result))
+            {
+                Interlocked.Increment(ref failures[0]);
+            }
+        });
+
+        Assert.AreEqual(0, failures[0]);
+    }
+
+    private static Foo CreateFoo()
+    {
+        Foo foo = new Foo();
+        foo.InternalValue = 41;
+        return foo;
+    }
+
+    private static Dictionary<string, object> CreateVariables()
+    {
+        Dictionary<string, object> variables = new Dictionary<string, object>();
+        variables["foo"] = CreateFoo();
+        return variables;
+    }
+
+    private static string MissingMethodMessage(string methodName)
+    {
+        return string.Format("Method '{0}' with the specified number and types of arguments does not exist.", methodName);
+    }
+
+    private static string ArityMessage(string extensionName, Type targetType, int expected, int actual)
+    {
+        return string.Format("Extension '{0}' registered for type '{1}' expects {2} argument(s) including the receiver, but was called with {3}.", extensionName, targetType.FullName, expected, actual);
+    }
+
+    private interface IHasValue
+    {
+        int InternalValue { get; }
+    }
+
+    private class Foo : IHasValue
+    {
+        public int InternalValue { get; set; }
+
+        public override string ToString()
+        {
+            return "real";
+        }
+    }
+
+    private class Bar : Foo
+    {
+    }
+
+    private class Baz : IHasValue
+    {
+        public int InternalValue { get; set; }
+    }
+
+    private class Holder
+    {
+        public Foo Child { get; set; }
+    }
+
+    private class MyTestMethodCallProcessor : IMethodCallProcessor
+    {
+        public object Process(object context, object[] args)
+        {
+            return "processor";
+        }
+    }
+}

--- a/test/Spring/Spring.Core.Tests/Expressions/MethodNodeTests.cs
+++ b/test/Spring/Spring.Core.Tests/Expressions/MethodNodeTests.cs
@@ -49,6 +49,31 @@ public class MethodNodeTests
         Assert.AreSame(input, exp.GetValue(input, vars));
     }
 
+    private class HasCompute
+    {
+        public int Compute()
+        {
+            return 1;
+        }
+    }
+
+    private class NoCompute
+    {
+    }
+
+    [Test]
+    public void DoesNotReuseMethodCachedForDifferentContextType()
+    {
+        IExpression exp = Expression.Parse("Compute()");
+
+        Assert.AreEqual(1, exp.GetValue(new HasCompute()));
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => exp.GetValue(new NoCompute()));
+        Assert.AreEqual("Method 'Compute' with the specified number and types of arguments does not exist.", ex.Message);
+
+        Assert.AreEqual(1, exp.GetValue(new HasCompute()));
+    }
+
     [Test, Explicit]
     public void PerformanceOfMethodEvaluationOnDifferentContextTypes()
     {


### PR DESCRIPTION
Implements user-registrable **extension methods** and **extension properties** for Spring expressions, closing a long-standing feature request.

Closes #221

## What this adds

Registration is scoped to a variables dictionary (not global) and accepts either a Spring lambda expression or a .NET delegate; new statics live on `Expression` beside `RegisterFunction`:

```csharp
IDictionary<string, object> vars = new Dictionary<string, object>();
vars["foo"] = new Foo { InternalValue = 41 };

Expression.RegisterExtensionMethod<Foo>("AddTo", "{|self, arg| $self.InternalValue + $arg}", vars);
ExpressionEvaluator.GetValue(null, "#foo.AddTo(1)", vars);   // 42

Expression.RegisterExtensionProperty("Doubled", (Foo self) => self.InternalValue * 2, vars);
ExpressionEvaluator.GetValue(null, "#foo.Doubled", vars);    // 82
```

Typed `Func<>` overloads cover receiver + 0-3 arguments (with full generic inference from typed lambdas); a `System.Delegate` overload covers everything else; non-generic `Type`-taking variants exist for all forms.

## Resolution semantics

- **Real CLR members always win** - extensions are consulted only when method/property resolution finds no member, so an extension can never shadow a real one, and all pre-existing "not found" exception messages are preserved byte-for-byte.
- Dispatch is on the receiver''s **runtime type**, walking base classes then interfaces; most-derived registration wins; name lookup is case-insensitive (matching CLR member lookup).
- The registry is a single object stored under a reserved `____spring_` key with copy-on-write tables - evaluation is lock-free and concurrent-safe.
- Extension properties are read-only in v1 (assignment throws `NotWritablePropertyException`).
- No grammar/ANTLR changes - both fallbacks slot into existing member resolution.
- One correction vs. the issue''s example: the receiver must be an *instance* (`#foo.AddTo(1)`); a bare `Foo` parses as a type name. Documented in the new reference section.

## Pre-existing bugs fixed along the way

- `MethodNode.Initialize` left a **stale cached method** when the same parsed expression was later evaluated against a type lacking the method - the cached `SafeMethod` for type A was invoked against a type-B receiver. Now cleared, with a negative-result cache and a dedicated regression test.
- The cache-hash computation disagreed between lookup (`context.GetType()`) and store (`context is Type ? ... `) for `Type` receivers, forcing re-resolution on every evaluation.

## Deliberate choices worth flagging

- Legacy `ICollectionProcessor`/`IMethodCallProcessor` variables keep their historical precedence (they still shadow CLR members); the new mechanism is CLR-first. The asymmetry is intentional to avoid behavior changes for existing users, and is documented.
- The new API takes `IDictionary<string, object>` (generic) while `RegisterFunction` keeps its pre-generics `IDictionary` - only the generic form is accepted by `GetValue`, and offering both overloads would be CS0121-ambiguous.
- `changelog.txt` untouched per repo convention (release-prep commits own it).

## Testing

- 36 new tests (dual-TFM `ExpressionExtensionTests` + `MethodNode` cache regression): precedence, cross-dictionary isolation, inheritance/interface dispatch, arity/registration validation, exception-message preservation, `Parallel.For` concurrency.
- Full `Spring.Core.Tests`, `Spring.Aop.Tests`, `Spring.Data.Tests` green on net8.0 and net462; solution builds with 0 warnings.
- New reference-manual section "Extension Methods and Properties" in `doc/reference/src/expressions.xml` with the complete resolution-rules list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)